### PR TITLE
Test enhancemnt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4",
+        "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "~2.0",
         "vectorface/dunit": "~2.0",
         "codeclimate/php-test-reporter": "dev-master"

--- a/tests/APCCacheTest.php
+++ b/tests/APCCacheTest.php
@@ -7,7 +7,7 @@ use Vectorface\Cache\APCCache;
 
 class APCCacheTest extends GenericCacheTest
 {
-    public function setUp()
+    protected function setUp()
     {
         $apc = extension_loaded('apc') || extension_loaded('apcu');
         if (!$apc || (PHP_SAPI == 'cli' && ini_get('apc.enable_cli') !== '1')) {

--- a/tests/CacheHelperTest.php
+++ b/tests/CacheHelperTest.php
@@ -5,8 +5,9 @@ namespace Vectorface\Tests\Cache;
 use Vectorface\Cache\Cache;
 use Vectorface\Cache\PHPCache;
 use Vectorface\Cache\CacheHelper;
+use PHPUnit\Framework\TestCase;
 
-class CacheHelperTest extends \PHPUnit_Framework_TestCase
+class CacheHelperTest extends TestCase
 {
     public function testCacheHelper()
     {

--- a/tests/GenericCacheTest.php
+++ b/tests/GenericCacheTest.php
@@ -3,8 +3,9 @@
 namespace Vectorface\Tests\Cache;
 
 use Vectorface\Cache\Cache;
+use PHPUnit\Framework\TestCase;
 
-abstract class GenericCacheTest extends \PHPUnit_Framework_TestCase
+abstract class GenericCacheTest extends TestCase
 {
     /**
      * The cache entry to be set by child classes.

--- a/tests/NullCacheTest.php
+++ b/tests/NullCacheTest.php
@@ -4,8 +4,9 @@ namespace Vectorface\Tests\Cache;
 
 use Vectorface\Cache\Cache;
 use Vectorface\Cache\NullCache;
+use PHPUnit\Framework\TestCase;
 
-class NullCacheTest extends \PHPUnit_Framework_TestCase
+class NullCacheTest extends TestCase
 {
     public function testNullCache()
     {

--- a/tests/PHPCacheTest.php
+++ b/tests/PHPCacheTest.php
@@ -7,7 +7,7 @@ use Vectorface\Cache\PHPCache;
 
 class PHPCacheTest extends GenericCacheTest
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->cache = new PHPCache();
     }

--- a/tests/SQLCacheTest.php
+++ b/tests/SQLCacheTest.php
@@ -10,7 +10,7 @@ class SQLCacheTest extends GenericCacheTest
 {
     private $pdo;
 
-    public function setUp()
+    protected function setUp()
     {
         try {
             $this->pdo = new \PDO('sqlite::memory:', null, null, array(\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION));

--- a/tests/TempFileCacheTest.php
+++ b/tests/TempFileCacheTest.php
@@ -7,12 +7,12 @@ use Vectorface\Cache\TempFileCache;
 
 class TempFileCacheTest extends GenericCacheTest
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->cache = new TempFileCache();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->cache->destroy();
     }

--- a/tests/TieredCacheTest.php
+++ b/tests/TieredCacheTest.php
@@ -6,8 +6,9 @@ use Vectorface\Cache\Cache;
 use Vectorface\Cache\NullCache;
 use Vectorface\Cache\PHPCache;
 use Vectorface\Cache\TieredCache;
+use PHPUnit\Framework\TestCase;
 
-class TieredCacheTest extends \PHPUnit_Framework_TestCase
+class TieredCacheTest extends TestCase
 {
     public function testTieredCache()
     {


### PR DESCRIPTION
# Changed log

- Using the class-based PHPUnit namespace to support the latest PHPUnit versions.
- According to the [PHPUnit fixture](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures#more-setup-than-teardown) reference, the `setUp` method is protected, not public.