### PR TITLE
PSR-16 Implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     },
     "require": {
         "php": "^7.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1",
+        "psr/simple-cache": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0 || ^7.0",
@@ -30,6 +31,8 @@
         "codeclimate/php-test-reporter": "dev-master"
     },
     "suggest": {
-        "ext-apcu": "*"
+        "ext-pdo": "Needed to support in an SQL database",
+        "ext-apcu": "Needed to support caching in APC(u)",
+        "ext-memcache": "Needed to support caching with the Memcache extension"
     }
 }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -26,7 +26,7 @@ interface Cache extends CacheInterface
      *
      * @param String $key The key/index for the cache entry
      * @param mixed $value The item to store in the cache
-     * @param null|int $ttl The time to live of the cached item. Not all caches honor the TTL.
+     * @param null|int|DateInterval $ttl The time to live of the cached item. Not all caches honor the TTL.
      * @return bool True if successful, false otherwise.
      */
     public function set($key, $value, $ttl = null);

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -2,18 +2,21 @@
 
 namespace Vectorface\Cache;
 
+use DateInterval;
+use Psr\SimpleCache\CacheInterface;
+
 /**
  * Cache: A common interface to various types of caches
  * N.B. This interface would conflict with any class named Cache in the future
  * such as an ormdata generated Cache{Peer} class to match the database table.
  */
-interface Cache
+interface Cache extends CacheInterface
 {
     /**
      * Fetch a cache entry by key.
      *
      * @param String $key The key for the entry to fetch
-     * @param mixed  $default Default value to return if the key does not exist.
+     * @param mixed  $default Default value to return if the key does not exist
      * @return mixed The value stored in the cache for $key
      */
     public function get($key, $default = null);
@@ -23,10 +26,10 @@ interface Cache
      *
      * @param String $key The key/index for the cache entry
      * @param mixed $value The item to store in the cache
-     * @param int $ttl The time to live (or expiry) of the cached item. Not all caches honor the TTL.
+     * @param null|int $ttl The time to live of the cached item. Not all caches honor the TTL.
      * @return bool True if successful, false otherwise.
      */
-    public function set($key, $value, $ttl = false);
+    public function set($key, $value, $ttl = null);
 
     /**
      * Remove an entry from the cache.

--- a/src/Common/MultipleTrait.php
+++ b/src/Common/MultipleTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Vectorface\Cache\Common;
+
+/**
+ * Wraps (get|set|delete) operations with their multiple counterparts
+ *
+ * This is useful when the underlying cache doesn't implement multi ops
+ */
+trait MultipleTrait
+{
+    abstract protected function keys($keys);
+
+    /**
+     * @inheritDoc \Psr\SimpleCache\CacheInterface
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $values = [];
+        foreach ($this->keys($keys) as $key) {
+            $values[$key] = $this->get($key, $default);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @inheritDoc \Psr\SimpleCache\CacheInterface
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $success = true;
+        foreach ($this->values($values) as $key => $value) {
+            $success = $this->set($key, $value, $ttl) && $success;
+        }
+        return $success;
+    }
+
+    /**
+     * @inheritDoc \Psr\SimpleCache\CacheInterface
+     */
+    public function deleteMultiple($keys)
+    {
+        $success = true;
+        foreach ($keys as $key) {
+            $success = $this->delete($key) && $success;
+        }
+        return $success;
+    }
+}

--- a/src/Common/PSR16Util.php
+++ b/src/Common/PSR16Util.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Vectorface\Cache\Common;
+
+use DateInterval;
+use DateTime;
+use Traversable;
+use Vectorface\Cache\Exception\CacheException;
+use Vectorface\Cache\Exception\InvalidArgumentException as CacheArgumentException;
+
+
+/**
+ *
+ */
+trait PSR16Util
+{
+    /**
+     * The DateTime implementation to use
+     *
+     * @var string
+     */
+    private static $dateTimeClass = DateTime::class;
+
+    /**
+     * Enforce a fairly standard key format
+     *
+     * @param $key
+     * @return mixed Returns the key, if valid
+     * @throws CacheArgumentException Thrown if the key is not a legal value
+     */
+    protected function key($key)
+    {
+        if (is_scalar($key)) {
+            return $key;
+        }
+
+        throw new CacheArgumentException("key is not a legal value");
+    }
+
+    /**
+     * Enforce fairly standard key formats on an iterable of values
+     * @param iterable $values
+     * @return iterable The values array
+     * @throws CacheArgumentException Thrown if any of the keys is not a legal value
+     */
+    protected function values($values) {
+        foreach ($values as $key => $value) {
+            $key = $this->key($key); // Checks the key
+        }
+        return $values;
+    }
+
+    /**
+     * Enforce a fairly standard key format on an array or Traversable of keys
+     *
+     * @param iterable $keys
+     * @return mixed Returns the key, if valid
+     * @throws CacheArgumentException Thrown if any of the keys is not a legal value
+     */
+    protected function keys($keys)
+    {
+        if (!is_array($keys) && !($keys instanceof Traversable)) {
+            throw new CacheArgumentException("keys must be provided as an array or a Traversable");
+        }
+
+        foreach ($keys as &$key) {
+            $key = $this->key($key);
+        }
+        return $keys;
+    }
+
+    /**
+     * Add defaults to an array of values from a cache
+     *
+     * Note: This does NOT check the keys array
+     *
+     * @param array|iterable $keys An array of expected keys
+     * @param array $values An array of values pulled from the cache
+     * @param mixed $default The default value to be populated for missing entries
+     * @return array The values array, with defaults added
+     */
+    protected static function defaults($keys, $values, $default)
+    {
+        foreach ($keys as $key) {
+            if (!isset($values[$key])) {
+                $values[$key] = $default;
+            }
+        }
+        return $values;
+    }
+
+    /**
+     * Convert a PSR-16 compatible TTL argument to a standard integer TTL as used by most caches
+     *
+     * @param null|int|DateInterval $ttl
+     * @return int
+     */
+    public static function ttl($ttl)
+    {
+        if (is_numeric($ttl) || $ttl === null) {
+            return $ttl;
+        } elseif ($ttl instanceof DateInterval) {
+            return static::intervalToTTL($ttl);
+        }
+
+        throw new CacheArgumentException("TTL must be specified as a number, a DateInterval, or null");
+    }
+
+    /**
+     * Convert a DateInterval to a time diff in seconds
+     * @param DateInterval $interval
+     * @return int The number of seconds from now until $interval
+     */
+    public static function intervalToTTL(DateInterval $interval)
+    {
+        $dateClass = static::$dateTimeClass;
+
+        try {
+            $now = new $dateClass();
+            $exp = (new $dateClass())->add($interval);
+        } catch (\Exception $e) {
+            throw new CacheException("Could not get current DateTime");
+        }
+
+        return $exp->getTimestamp() - $now->getTimestamp();
+    }
+}

--- a/src/Common/PSR16Util.php
+++ b/src/Common/PSR16Util.php
@@ -10,7 +10,7 @@ use Vectorface\Cache\Exception\InvalidArgumentException as CacheArgumentExceptio
 
 
 /**
- *
+ * Utility methods common to many PSR-16 cache implementations
  */
 trait PSR16Util
 {
@@ -24,8 +24,8 @@ trait PSR16Util
     /**
      * Enforce a fairly standard key format
      *
-     * @param $key
-     * @return mixed Returns the key, if valid
+     * @param mixed $key
+     * @return int|float|string|bool Returns the key, if valid
      * @throws CacheArgumentException Thrown if the key is not a legal value
      */
     protected function key($key)
@@ -54,7 +54,7 @@ trait PSR16Util
      * Enforce a fairly standard key format on an array or Traversable of keys
      *
      * @param iterable $keys
-     * @return mixed Returns the key, if valid
+     * @return mixed[] Returns the keys, if valid
      * @throws CacheArgumentException Thrown if any of the keys is not a legal value
      */
     protected function keys($keys)

--- a/src/Common/PSR16Util.php
+++ b/src/Common/PSR16Util.php
@@ -44,10 +44,15 @@ trait PSR16Util
      * @throws CacheArgumentException Thrown if any of the keys is not a legal value
      */
     protected function values($values) {
-        foreach ($values as $key => $value) {
-            $key = $this->key($key); // Checks the key
+        if (!is_array($values) && !($values instanceof Traversable)) {
+            throw new CacheArgumentException("values must be provided as an array or a Traversable");
         }
-        return $values;
+
+        $array = [];
+        foreach ($values as $key => $value) {
+            $array[$this->key($key)] = $value;
+        }
+        return $array;
     }
 
     /**
@@ -63,10 +68,11 @@ trait PSR16Util
             throw new CacheArgumentException("keys must be provided as an array or a Traversable");
         }
 
-        foreach ($keys as &$key) {
-            $key = $this->key($key);
+        $array = [];
+        foreach ($keys as $key) {
+            $array[] = $this->key($key);
         }
-        return $keys;
+        return $array;
     }
 
     /**

--- a/src/Exception/CacheException.php
+++ b/src/Exception/CacheException.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Vectorface\Cache\Exception;
+
+use Exception;
+use Psr\SimpleCache\CacheException as SimpleCacheException;
+
+class CacheException extends Exception implements SimpleCacheException
+{
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Vectorface\Cache\Exception;
+
+use InvalidArgumentException as ParentInvalidArgumentException;
+use Psr\SimpleCache\InvalidArgumentException as SimpleCacheInvalidArgumentException;
+
+class InvalidArgumentException extends ParentInvalidArgumentException implements SimpleCacheInvalidArgumentException
+{
+}

--- a/src/LogDecorator.php
+++ b/src/LogDecorator.php
@@ -122,6 +122,71 @@ class LogDecorator implements Cache
     }
 
     /**
+     * @inheritDoc
+     */
+    public function clear()
+    {
+        return $this->flush();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $values = $this->cache->getMultiple($keys, $default);
+        $this->log(sprintf(
+            "getMultiple [%s] count=%d",
+            implode(', ', $keys),
+            count($values)
+        ));
+        return $values;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $result = $this->cache->setMultiple($values, $ttl);
+        $this->log(sprintf(
+            "setMultiple [%s] %s ttl=%s",
+            implode(', ', array_keys($values)),
+            $result ? 'SUCCESS' : 'FAILURE',
+            is_numeric($ttl) ? $ttl : "null"
+        ));
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteMultiple($keys)
+    {
+        $result = $this->cache->deleteMultiple($keys);
+        $this->log(sprintf(
+            "deleteMultiple [%s] %s",
+            implode(', ', $keys),
+            $result ? 'SUCCESS' : 'FAILURE'
+        ));
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($key)
+    {
+        $result = $this->cache->has($key);
+        $this->log(sprintf(
+            "has %s %s",
+            $key,
+            $result ? 'true' : 'false'
+        ));
+        return $result;
+    }
+
+    /**
      * Log a message to the configured logger
      *
      * @param $message

--- a/src/NullCache.php
+++ b/src/NullCache.php
@@ -2,17 +2,15 @@
 
 namespace Vectorface\Cache;
 
+use Vectorface\Cache\Common\PSR16Util;
+
 /**
  * A cache that caches nothing and always fails.
  */
 class NullCache implements Cache
 {
     /**
-     * Fetch a cache entry by key.
-     *
-     * @param String $key The key for the entry to fetch
-     * @param mixed  $default Default value to return if the key does not exist.
-     * @return mixed The value stored in the cache for $key, or false on failure.
+     * @inheritDoc Vectorface\Cache\Cache
      */
     public function get($key, $default = null)
     {
@@ -20,23 +18,15 @@ class NullCache implements Cache
     }
 
     /**
-     * Set an entry in the cache.
-     *
-     * @param String $key The key/index for the cache entry
-     * @param mixed $value The item to store in the cache
-     * @param int $ttl The time to live (or expiry) of the cached item. Not all caches honor the TTL.
-     * @return bool True if successful, false otherwise.
+     * @inheritDoc Vectorface\Cache\Cache
      */
-    public function set($key, $value, $ttl = false)
+    public function set($key, $value, $ttl = null)
     {
         return false;
     }
 
     /**
-     * Remove an entry from the cache.
-     *
-     * @param String $key The key to be deleted (removed) from the cache.
-     * @return bool True if successful, false otherwise.
+     * @inheritDoc Vectorface\Cache\Cache
      */
     public function delete($key)
     {
@@ -44,9 +34,7 @@ class NullCache implements Cache
     }
 
     /**
-     * Manually clean out entries older than their TTL
-     *
-     * @return bool True if successful, false otherwise.
+     * @inheritDoc Vectorface\Cache\Cache
      */
     public function clean()
     {
@@ -54,11 +42,49 @@ class NullCache implements Cache
     }
 
     /**
-     * Clear the cache.
-     *
-     * @return bool True if successful, false otherwise.
+     * @inheritDoc Vectorface\Cache\Cache
      */
     public function flush()
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc Psr\SimpleCache\CacheInterface
+     */
+    public function clear()
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        return array_combine($keys, array_fill(0, count($keys), $default));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteMultiple($keys)
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($key)
     {
         return false;
     }

--- a/src/SQLCache.php
+++ b/src/SQLCache.php
@@ -228,16 +228,17 @@ class SQLCache implements Cache
             return true;
         }
 
-        foreach ($keys as &$key) {
-            $key = (strlen($key) > self::MAX_KEY_LEN) ? $this->hashKey($key) : $key;
+        $keysArray = [];
+        foreach ($keys as $key) {
+            $keysArray[] = (strlen($key) > self::MAX_KEY_LEN) ? $this->hashKey($key) : $key;
         }
 
         try {
             $stmt = $this->conn->prepare(sprintf(
                 self::MDELETE_SQL,
-                implode(',', array_fill(0, count($keys), '?'))
+                implode(',', array_fill(0, count($keysArray), '?'))
             ));
-            $stmt->execute($keys);
+            $stmt->execute($keysArray);
         } catch (PDOException $e) {
             return false;
         }

--- a/src/SQLCache.php
+++ b/src/SQLCache.php
@@ -197,7 +197,7 @@ class SQLCache implements Cache
     public function setMultiple($values, $ttl = null)
     {
         $success = true;
-        foreach ($values as $key => $value) {
+        foreach ($this->values($values) as $key => $value) {
             $success = $this->set($key, $value, $ttl) && $success;
         }
         return $success;

--- a/tests/APCCacheTest.php
+++ b/tests/APCCacheTest.php
@@ -7,7 +7,7 @@ use Vectorface\Cache\APCCache;
 
 class APCCacheTest extends GenericCacheTest
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!extension_loaded('apcu') || (ini_get('apc.enable_cli') !== '1')) {
             $this->markTestSkipped("APCu module not loaded, or not enabled");

--- a/tests/CacheHelperTest.php
+++ b/tests/CacheHelperTest.php
@@ -5,8 +5,9 @@ namespace Vectorface\Tests\Cache;
 use Vectorface\Cache\Cache;
 use Vectorface\Cache\PHPCache;
 use Vectorface\Cache\CacheHelper;
+use PHPUnit\Framework\TestCase;
 
-class CacheHelperTest extends \PHPUnit\Framework\TestCase
+class CacheHelperTest extends TestCase
 {
     public function testCacheHelper()
     {

--- a/tests/Common/PSR16UtilTest.php
+++ b/tests/Common/PSR16UtilTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Vectorface\Tests\Cache;
+
+use DateInterval;
+use Vectorface\Cache\PHPCache;
+use PHPUnit\Framework\TestCase;
+use Vectorface\Tests\Cache\Helpers\BrokenDateTime;
+
+class PSR16UtilTest extends TestCase
+{
+    /**
+     * @expectedException Vectorface\Cache\Exception\InvalidArgumentException
+     */
+    public function testEnforcesScalarKey()
+    {
+        (new PHPCache)->get(new \stdClass);
+    }
+
+    /**
+     * @expectedException Vectorface\Cache\Exception\InvalidArgumentException
+     */
+    public function testEnforcesScalarKeys()
+    {
+        (new PHPCache)->getMultiple([new \stdClass()]);
+    }
+
+    /**
+     * @expectedException Vectorface\Cache\Exception\InvalidArgumentException
+     */
+    public function testEnforcesIterableKeys()
+    {
+        (new PHPCache)->getMultiple("not array or Traversable");
+    }
+
+    public function testConvertsDateIntervalToTtl()
+    {
+        $this->assertEquals(86462, PHPCache::ttl(new DateInterval("P0000-00-01T00:01:02")));
+    }
+
+    /**
+     * @expectedException Vectorface\Cache\Exception\CacheException
+     */
+    public function testBrokenDateTime()
+    {
+        $ref = new \ReflectionClass(\Vectorface\Cache\PHPCache::class);
+        $prop = $ref->getProperty('dateTimeClass');
+        $prop->setAccessible(true);
+        $prop->setValue(null, BrokenDateTime::class);
+
+        PHPCache::ttl(new DateInterval("P0000-00-01T00:01:02"));
+    }
+}

--- a/tests/GenericCacheTest.php
+++ b/tests/GenericCacheTest.php
@@ -3,8 +3,12 @@
 namespace Vectorface\Tests\Cache;
 
 use Vectorface\Cache\Cache;
+use PHPUnit\Framework\TestCase;
+use Vectorface\Cache\Exception\InvalidArgumentException;
+use Psr\SimpleCache\InvalidArgumentException as IInvalidArgumentException;
+use Psr\SimpleCache\CacheInterface;
 
-abstract class GenericCacheTest extends \PHPUnit\Framework\TestCase
+abstract class GenericCacheTest extends TestCase
 {
     /**
      * The cache entry to be set by child classes.
@@ -17,6 +21,7 @@ abstract class GenericCacheTest extends \PHPUnit\Framework\TestCase
     {
         foreach ($this->getCaches() as $cache) {
             $this->assertTrue($cache instanceof Cache);
+            $this->assertTrue($cache instanceof CacheInterface);
         }
     }
 
@@ -36,15 +41,47 @@ abstract class GenericCacheTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    public function testMultipleOperations()
+    {
+        $values = [
+            'foo' => 'bar',
+            'baz' => 'quux',
+        ];
+        foreach ($this->getCaches() as $cache) {
+            $this->assertEquals(
+                ['foo' => 'dflt', 'baz' => 'dflt'],
+                $cache->getMultiple(array_keys($values), 'dflt')
+            , "Expected the result to be populated with default values");
+            $this->assertEquals([], $cache->getMultiple([]));
+            $this->assertTrue($cache->setMultiple($values));
+            $this->assertEquals($values, $cache->getMultiple(array_keys($values)));
+            $this->assertTrue($cache->deleteMultiple(array_keys($values)));
+            $this->assertTrue($cache->deleteMultiple([]));
+            $this->assertEquals(
+                ['foo' => 'dflt', 'baz' => 'dflt'],
+                $cache->getMultiple(array_keys($values), 'dflt')
+            );
+        }
+    }
+
     /**
      * @dataProvider cacheDataProvider
      */
     public function testDelete($key, $data, $ttl)
     {
         foreach ($this->getCaches() as $cache) {
-            $cache->set($key, $data, $ttl);
-            $cache->delete($key);
+            $this->assertTrue($cache->set($key, $data, $ttl));
+            $this->assertTrue($cache->delete($key));
             $this->assertNull($cache->get($key));
+        }
+    }
+
+    public function testHas()
+    {
+        foreach ($this->getCaches() as $cache) {
+            $this->assertFalse($cache->has(__FUNCTION__));
+            $this->assertTrue($cache->set(__FUNCTION__, __METHOD__));
+            $this->assertTrue($cache->has(__FUNCTION__));
         }
     }
 
@@ -62,13 +99,48 @@ abstract class GenericCacheTest extends \PHPUnit\Framework\TestCase
      */
     public function testFlush($key, $data, $ttl)
     {
+        $this->realTestFlushAndClear($key, $data, $ttl, true);
+    }
+
+    /**
+     * @dataProvider cacheDataProvider
+     */
+    public function testClear($key, $data, $ttl)
+    {
+        $this->realTestFlushAndClear($key, $data, $ttl, false);
+    }
+
+    public function realTestFlushAndClear($key, $data, $ttl, $flush)
+    {
         foreach ($this->getCaches() as $cache) {
             $cache->set($key, $data, $ttl);
             $cache->set($key."2", $data, $ttl + 50000);
-            $cache->flush();
+            $flush ? $cache->flush() : $cache->clear();
 
             $this->assertNull($cache->get($key));
             $this->assertNull($cache->get($key . ".unrelated"));
+        }
+    }
+
+    public function testPSR16()
+    {
+        $expectIAE = function($callback, $message) {
+            try {
+                $callback();
+                $this->fail("$message: Expected exception");
+            } catch (InvalidArgumentException $e) {
+                $this->assertInstanceOf(
+                    IInvalidArgumentException::class,
+                    $e,
+                    "$message: Expected Psr\SimpleCache\InvalidArgumentException"
+                );
+            }
+        };
+
+        foreach ($this->getCaches() as $cache) {
+            $expectIAE(function() use($cache) { $cache->get(new \stdClass()); }, "Invalid key in get");
+            $expectIAE(function() use($cache) { $cache->set(new \stdClass(), "value"); }, "Invalid key in set, exception expected");
+            $expectIAE(function() use($cache) { $cache->set("key", "value", []); }, "Invalid ttl in " . get_class($cache) . " set, exception expected");
         }
     }
 

--- a/tests/GenericCacheTest.php
+++ b/tests/GenericCacheTest.php
@@ -50,8 +50,9 @@ abstract class GenericCacheTest extends TestCase
         foreach ($this->getCaches() as $cache) {
             $this->assertEquals(
                 ['foo' => 'dflt', 'baz' => 'dflt'],
-                $cache->getMultiple(array_keys($values), 'dflt')
-            , "Expected the result to be populated with default values");
+                $cache->getMultiple(array_keys($values), 'dflt'),
+                "Expected the result to be populated with default values"
+            );
             $this->assertEquals([], $cache->getMultiple([]));
             $this->assertTrue($cache->setMultiple($values));
             $this->assertEquals($values, $cache->getMultiple(array_keys($values)));
@@ -62,6 +63,33 @@ abstract class GenericCacheTest extends TestCase
                 $cache->getMultiple(array_keys($values), 'dflt')
             );
         }
+    }
+
+    /**
+     * Use a generator to enforce that multiple interfaces are iterable-compatible
+     */
+    public function testTraversables()
+    {
+        foreach ($this->getCaches() as $cache) {
+            $this->assertEquals(
+                ['foo' => 'dflt', 'bar' => 'dflt'],
+                $cache->getMultiple(
+                    (function() { yield 'foo'; yield 'bar'; })(),
+                    'dflt'
+                ),
+                "Expected the result to be populated with default values"
+            );
+            $this->assertTrue($cache->setMultiple(
+                (function() { yield 'foo' => 'bar'; yield 'baz' => 'quux'; })()
+            ));
+            $this->assertEquals('bar', $cache->get('foo'));
+            $this->assertEquals('quux', $cache->get('baz'));
+            $this->assertTrue($cache->deleteMultiple((function() { yield 'foo'; yield 'baz'; })()));
+        }
+
+        //$traversable = (function() { yield 'foo' => 'bar'; yield 'baz' => 'quux'; })();
+
+
     }
 
     /**

--- a/tests/GenericCacheTest.php
+++ b/tests/GenericCacheTest.php
@@ -152,10 +152,10 @@ abstract class GenericCacheTest extends TestCase
 
     public function testPSR16()
     {
-        $expectIAE = function($callback, $message) {
+        $expectIAE = function($callback, $message = '') {
             try {
                 $callback();
-                $this->fail("$message: Expected exception");
+                $this->fail("$message: Expected exception, but none happened");
             } catch (InvalidArgumentException $e) {
                 $this->assertInstanceOf(
                     IInvalidArgumentException::class,
@@ -169,6 +169,8 @@ abstract class GenericCacheTest extends TestCase
             $expectIAE(function() use($cache) { $cache->get(new \stdClass()); }, "Invalid key in get");
             $expectIAE(function() use($cache) { $cache->set(new \stdClass(), "value"); }, "Invalid key in set, exception expected");
             $expectIAE(function() use($cache) { $cache->set("key", "value", []); }, "Invalid ttl in " . get_class($cache) . " set, exception expected");
+            $expectIAE(function() use($cache) { $cache->getMultiple(new \Exception()); }, "Shouldn't be able to getMultiple with a non-iterable");
+            $expectIAE(function() use($cache) { $cache->setMultiple(new \Exception()); }, "Shouldn't be able to setMultiple on a non-iterable");
         }
     }
 

--- a/tests/Helpers/BrokenDateTime.php
+++ b/tests/Helpers/BrokenDateTime.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Vectorface\Tests\Cache\Helpers;
+
+use DateTime;
+
+class BrokenDateTime extends DateTime
+{
+    public function __construct(...$args)
+    {
+        throw new \Exception("I'm broken for tests!");
+    }
+}

--- a/tests/Helpers/FakeMemcache.php
+++ b/tests/Helpers/FakeMemcache.php
@@ -19,7 +19,7 @@ class FakeMemcache extends \Memcache
      *
      * @var bool
      */
-    public static $broken = false;
+    public $broken = false;
 
     /**
      * Mimic Memcache::get
@@ -28,8 +28,16 @@ class FakeMemcache extends \Memcache
      */
     public function get($key, &$flags = null, &$unused = null)
     {
-        if (self::$broken) {
+        if ($this->broken) {
             return false;
+        }
+
+        if (is_array($key)) {
+            $values = [];
+            foreach ($key as $k) {
+                $values[$k] = $this->get($k);
+            }
+            return $values;
         }
 
         return isset(static::$cache[$key]) ? static::$cache[$key] : false;
@@ -42,7 +50,7 @@ class FakeMemcache extends \Memcache
      */
     public function set($key, $value, $flags = null, $ttl = 0)
     {
-        if (self::$broken) {
+        if ($this->broken) {
             return false;
         }
 
@@ -57,8 +65,11 @@ class FakeMemcache extends \Memcache
      */
     public function flush()
     {
+        if ($this->broken) {
+            return false;
+        }
         static::$cache = [];
-        return self::$broken ? false : true;
+        return true;
     }
 
     /**
@@ -68,6 +79,9 @@ class FakeMemcache extends \Memcache
      */
     public function replace($key, $value, $flag = null, $expire = 0)
     {
+        if ($this->broken) {
+            return false;
+        }
         $old = $this->get($key);
         if ($old === false) {
             return false;
@@ -83,6 +97,10 @@ class FakeMemcache extends \Memcache
      */
     public function increment($key, $value = 1)
     {
+        if ($this->broken) {
+            return false;
+        }
+
         $old = $this->get($key);
         if ($old === false) {
             return false;
@@ -108,8 +126,11 @@ class FakeMemcache extends \Memcache
      *
      * @see http://php.net/manual/en/memcache.delete.php
      */
-    public function delete($key)
+    public function delete($key, $timeout = 0)
     {
+        if ($this->broken) {
+            return false;
+        }
         unset(static::$cache[$key]);
         return true;
     }

--- a/tests/Helpers/TestPHPCache.php
+++ b/tests/Helpers/TestPHPCache.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Vectorface\Tests\Cache\Helpers;
+
+use Vectorface\Cache\PHPCache;
+
+class TestPHPCache extends PHPCache
+{
+    public $cache = [];
+
+    public function normalizeKeys(callable $fn = null)
+    {
+        parent::normalizeKeys($fn);
+    }
+}

--- a/tests/Helpers/fake_realpath.php
+++ b/tests/Helpers/fake_realpath.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Allow realpath to fail by overriding it in the namespace
+ */
+namespace Vectorface\Cache;
+
+class FakeRealpath
+{
+    public static $broken = false;
+    public static function realpath(...$args)
+    {
+        if (static::$broken) {
+            return false;
+        }
+
+        return \realpath(...$args);
+    }
+}
+
+function realpath(...$args)
+{
+    return FakeRealpath::realpath(...$args);
+}

--- a/tests/LogDecoratorTest.php
+++ b/tests/LogDecoratorTest.php
@@ -24,29 +24,37 @@ class LogDecoratorTest extends \PHPUnit\Framework\TestCase
          *
          * The following are successes with the PHPCache
          */
-        $result = $loggedCache->get("newKey", "dflt");
-        $this->assertEquals("dflt", $result);
+        $this->assertEquals("dflt", $loggedCache->get("newKey", "dflt"));
         $this->assertEquals("debug: get newKey MISS", $logger->getLastMessage());
 
-        $result = $loggedCache->set("testKey", "val", 123);
-        $this->assertEquals(true, $result);
+        $this->assertTrue($loggedCache->set("testKey", "val", 123));
         $this->assertEquals("debug: set testKey SUCCESS ttl=123, type=string, size=3", $logger->getLastMessage());
 
-        $result = $loggedCache->get("testKey", "dflt");
-        $this->assertEquals("val", $result);
+        $this->assertTrue($loggedCache->has("testKey"));
+        $this->assertEquals("debug: has testKey true", $logger->getLastMessage());
+
+        $this->assertEquals("val", $loggedCache->get("testKey", "dflt"));
         $this->assertEquals("debug: get testKey HIT size=3", $logger->getLastMessage());
 
-        $result = $loggedCache->delete("testKey");
-        $this->assertEquals(true, $result);
+        $this->assertTrue($loggedCache->delete("testKey"));
         $this->assertEquals("debug: delete testKey SUCCESS", $logger->getLastMessage());
 
-        $result = $loggedCache->clean();
-        $this->assertEquals(true, $result);
+        $this->assertTrue($loggedCache->clean());
         $this->assertEquals("debug: clean SUCCESS", $logger->getLastMessage());
 
-        $result = $loggedCache->flush();
-        $this->assertEquals(true, $result);
+        $this->assertTrue($loggedCache->flush());
         $this->assertEquals("debug: flush SUCCESS", $logger->getLastMessage());
+        $this->assertTrue($loggedCache->clear()); /* alias difference: PSR v.s. Internal*/
+        $this->assertEquals("debug: flush SUCCESS", $logger->getLastMessage());
+
+        $this->assertEquals(['foo' => null, 'bar' => null], $loggedCache->getMultiple(['foo', 'bar']));
+        $this->assertEquals("debug: getMultiple [foo, bar] count=2", $logger->getLastMessage());
+
+        $this->assertTrue($loggedCache->setMultiple(['foo' => 'bar', 'baz' => 'quux'], 123));
+        $this->assertEquals("debug: setMultiple [foo, baz] SUCCESS ttl=123", $logger->getLastMessage());
+
+        $this->assertTrue($loggedCache->deleteMultiple(['foo', 'baz']));
+        $this->assertEquals("debug: deleteMultiple [foo, baz] SUCCESS", $logger->getLastMessage());
     }
 
     public function testFailures()

--- a/tests/MCCacheTest.php
+++ b/tests/MCCacheTest.php
@@ -7,11 +7,24 @@ use Vectorface\Tests\Cache\Helpers\FakeMemcache;
 
 class MCCacheTest extends GenericCacheTest
 {
+    private $memcache;
+
     protected function setUp()
     {
         if (!class_exists("Memcache", false)) {
             class_alias("Vectorface\Tests\Cache\Helpers\Memcache", "Memcache");
         }
-        $this->cache = new MCCache(new FakeMemcache());
+        $this->memcache = new FakeMemcache();
+        $this->cache = new MCCache($this->memcache);
+    }
+
+    public function testGetMultipleWithBrokenCache()
+    {
+        $this->memcache->broken = true;
+        $this->assertEquals([
+            'foo' => 'baz',
+            'bar' => 'baz',
+        ], $this->cache->getMultiple(["foo", "bar"], "baz"));
+        $this->memcache->broken = false;
     }
 }

--- a/tests/NullCacheTest.php
+++ b/tests/NullCacheTest.php
@@ -4,8 +4,9 @@ namespace Vectorface\Tests\Cache;
 
 use Vectorface\Cache\Cache;
 use Vectorface\Cache\NullCache;
+use PHPUnit\Framework\TestCase;
 
-class NullCacheTest extends \PHPUnit\Framework\TestCase
+class NullCacheTest extends TestCase
 {
     public function testNullCache()
     {
@@ -16,5 +17,10 @@ class NullCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($cache->delete('foo'));
         $this->assertFalse($cache->clean());
         $this->assertFalse($cache->flush());
+        $this->assertFalse($cache->clear());
+        $this->assertEquals(['foo' => 'dflt', 'bar' => 'dflt'], $cache->getMultiple(['foo', 'bar'], 'dflt'));
+        $this->assertFalse($cache->setMultiple(['foo' => 'bar']));
+        $this->assertFalse($cache->deleteMultiple(['foo', 'bar']));
+        $this->assertFalse($cache->has('foo'));
     }
 }

--- a/tests/PHPCacheTest.php
+++ b/tests/PHPCacheTest.php
@@ -7,7 +7,7 @@ use Vectorface\Cache\PHPCache;
 
 class PHPCacheTest extends GenericCacheTest
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->cache = new PHPCache();
     }

--- a/tests/SQLCacheTest.php
+++ b/tests/SQLCacheTest.php
@@ -10,7 +10,7 @@ class SQLCacheTest extends GenericCacheTest
 {
     private $pdo;
 
-    public function setUp()
+    protected function setUp()
     {
         try {
             $this->pdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
@@ -27,7 +27,7 @@ class SQLCacheTest extends GenericCacheTest
     {
         /* Fail before statements are prepared. */
         $this->pdo->exec('DROP TABLE cache');
-        $this->assertFalse($this->cache->get('anything'));
+        $this->assertNull($this->cache->get('anything'));
         $this->assertFalse($this->cache->set('anything', 'anything'));
         $this->assertFalse($this->cache->delete('anything'));
         $this->assertFalse($this->cache->clean());
@@ -48,11 +48,14 @@ class SQLCacheTest extends GenericCacheTest
 
         /* Make 'em fail afterwards. */
         $this->pdo->exec('DROP TABLE cache');
-        $this->assertFalse($this->cache->get('anything'));
+        $this->assertNull($this->cache->get('anything'));
         $this->assertFalse($this->cache->set('anything', 'anything'));
         $this->assertFalse($this->cache->delete('anything'));
         $this->assertFalse($this->cache->clean());
         $this->assertFalse($this->cache->flush());
+        $this->assertFalse($this->cache->has('anything'));
+        $this->assertFalse($this->cache->deleteMultiple(['foo', 'bar']));
+        $this->assertEquals(['foo' => 'dflt', 'bar' => 'dflt'], $this->cache->getMultiple(['foo', 'bar'], 'dflt'));
     }
 
     public function testLongKey()
@@ -82,7 +85,7 @@ class SQLCacheTest extends GenericCacheTest
             CREATE TABLE cache (
                 entry VARCHAR(64) PRIMARY KEY NOT NULL,
                 value LONGBLOB,
-                expires UNSIGNED INT DEFAULT NULL
+                expires UNSIGNED BIGINT DEFAULT NULL
             )
         ');
     }

--- a/tests/TempFileCacheTest.php
+++ b/tests/TempFileCacheTest.php
@@ -2,17 +2,19 @@
 
 namespace Vectorface\Tests\Cache;
 
+require __DIR__ . '/Helpers/fake_realpath.php';
+
 use Vectorface\Cache\Cache;
 use Vectorface\Cache\TempFileCache;
 
 class TempFileCacheTest extends GenericCacheTest
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->cache = new TempFileCache();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->cache->destroy();
     }
@@ -67,5 +69,17 @@ class TempFileCacheTest extends GenericCacheTest
 
         $this->assertTrue($this->cache->set('foo', 'bar', -1));
         $this->assertNull($this->cache->get('foo'));
+    }
+
+    public function testBrokenRealpath()
+    {
+        \Vectorface\Cache\FakeRealpath::$broken = true;
+        try {
+            new TempFileCache();
+            $this->fail("Expected realpath exception to be thrown");
+        } catch (\Exception $e) {
+            $this->assertTrue($e instanceof \Exception);
+        }
+        \Vectorface\Cache\FakeRealpath::$broken = false;
     }
 }

--- a/tests/TieredCacheTest.php
+++ b/tests/TieredCacheTest.php
@@ -6,8 +6,9 @@ use Vectorface\Cache\Cache;
 use Vectorface\Cache\NullCache;
 use Vectorface\Cache\PHPCache;
 use Vectorface\Cache\TieredCache;
+use PHPUnit\Framework\TestCase;
 
-class TieredCacheTest extends \PHPUnit\Framework\TestCase
+class TieredCacheTest extends TestCase
 {
     public function testTieredCache()
     {
@@ -16,11 +17,20 @@ class TieredCacheTest extends \PHPUnit\Framework\TestCase
         $tiered = new TieredCache($null, $php);
 
         $this->assertNull($tiered->get('foo')); // Default is null
+        $this->assertFalse($tiered->has('foo'));
         $this->assertTrue($tiered->set('foo', 'bar'));
+        $this->assertTrue($tiered->has('foo'));
         $this->assertEquals('bar', $tiered->get('foo'));
+        $this->assertEquals(['foo' => 'bar'], $tiered->getMultiple(['foo']));
+        $this->assertEquals(['foo' => 'bar', 'baz' => null], $tiered->getMultiple(['foo', 'baz']));
         $this->assertFalse($tiered->delete('foo')); // one op failed, so all fail.
         $this->assertFalse($tiered->clean()); // one op failed, so all fail.
         $this->assertFalse($tiered->flush()); // one op failed, so all fail.
+        $this->assertFalse($tiered->clear()); // same as flush
+
+        $this->assertTrue($tiered->setMultiple(['foo' => 'bar', 'baz' => 'quux']));
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'quux'], $tiered->getMultiple(['foo', 'baz']));
+        $this->assertFalse($tiered->deleteMultiple(['foo', 'baz'])); // one op failed, so all fail.
     }
 
     /**


### PR DESCRIPTION
This PR adds support for PSR-16 "Common Interface for Caching Libraries" on top of the existing interface.

The only minor backwards-compatibility breaks are:
 - The default values change from false to null to match PSR-16
 - The exceptions thrown change (though become more consistent)