### PR TITLE
Switch to adapter approach for PSR-16 instead of directly extending it

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -2,31 +2,124 @@
 
 namespace Vectorface\Cache;
 
-use Psr\SimpleCache\CacheInterface;
+use DateInterval;
+use Traversable;
+use Vectorface\Cache\Exception\CacheException;
+use Vectorface\Cache\Exception\InvalidArgumentException;
 
 /**
  * Cache: A common interface to various types of caches
  */
-interface Cache extends CacheInterface
+interface Cache
 {
     /**
-     * @inheritDoc
-     * @param array|\Traversable $keys A list of keys that can obtained in a single operation.
-     * @return array|\Traversable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     * Fetches a value from the cache.
+     *
+     * @param string $key     The unique key of this item in the cache.
+     * @param mixed  $default Default value to return if the key does not exist.
+     *
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function get($key, $default = null);
+
+    /**
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     *
+     * @param string                 $key   The key of the item to store.
+     * @param mixed                  $value The value of the item to store, must be serializable.
+     * @param null|int|DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws InvalidArgumentException|CacheException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function set($key, $value, $ttl = null);
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete($key);
+
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function clear();
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param array|Traversable $keys    A list of keys that can obtained in a single operation.
+     * @param mixed              $default Default value to return for keys that do not exist.
+     *
+     * @return array|Traversable A list of key => value pairs. Cache keys that do not exist or are stale will
+     *   have $default as value.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
      */
     public function getMultiple($keys, $default = null);
 
     /**
-     * @inheritDoc
-     * @param array|\Traversable $values A list of keys that can obtained in a single operation.
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param array|Traversable     $values A list of keys that can obtained in a single operation.
+     * @param null|int|DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
+     *                                       the driver supports TTL then the library may set a default value
+     *                                       for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws InvalidArgumentException|CacheException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
      */
     public function setMultiple($values, $ttl = null);
 
     /**
-     * @inheritDoc
-     * @param array|\Traversable $keys A list of keys that can obtained in a single operation.
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param array|Traversable $keys A list of keys that can obtained in a single operation.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
      */
     public function deleteMultiple($keys);
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has($key);
 
     /**
      * Manually clean out entries older than their TTL
@@ -36,7 +129,7 @@ interface Cache extends CacheInterface
     public function clean();
 
     /**
-     * Clear the cache. Equivalent to CacheInterface::clean()
+     * Clear the cache. Equivalent to CacheInterface::clear()
      *
      * @return bool True if successful, false otherwise.
      */

--- a/src/CacheHelper.php
+++ b/src/CacheHelper.php
@@ -30,6 +30,7 @@ class CacheHelper
      * @param mixed[] $args The arguments to be passed to the callback, if it needs to be called.
      * @param int $ttl If a value is to be set in the cache, set this expiry time (in seconds).
      * @return mixed The value stored in the cache, or returned by the callback.
+     * @throws Exception\CacheException
      */
     public static function fetch(Cache $cache, string $key, callable $callback, array $args = [], $ttl = 300)
     {

--- a/src/Common/PSR16Util.php
+++ b/src/Common/PSR16Util.php
@@ -8,7 +8,6 @@ use Traversable;
 use Vectorface\Cache\Exception\CacheException;
 use Vectorface\Cache\Exception\InvalidArgumentException as CacheArgumentException;
 
-
 /**
  * Utility methods common to many PSR-16 cache implementations
  */

--- a/src/LogDecorator.php
+++ b/src/LogDecorator.php
@@ -2,6 +2,7 @@
 
 namespace Vectorface\Cache;
 
+use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -43,7 +44,7 @@ class LogDecorator implements Cache
     {
         $levels = ['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'];
         if (!in_array($level, $levels)) {
-            throw new \InvalidArgumentException("Incompatible log level: $level");
+            throw new InvalidArgumentException("Incompatible log level: $level");
         }
 
         $this->cache = $cache;

--- a/src/SimpleCacheAdapter.php
+++ b/src/SimpleCacheAdapter.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Vectorface\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+use Traversable;
+
+/**
+ * Adapts a Vectorface cache instance to the PSR SimpleCache interface.
+ */
+class SimpleCacheAdapter implements CacheInterface
+{
+    /** @var Cache */
+    protected $cache;
+
+    /**
+     * Create an adapter over a Vectorface cache instance to the SimpleCache interface.
+     *
+     * @param Cache $cache
+     */
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($key, $default = null)
+    {
+        return $this->cache->get($key, $default);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exception\CacheException
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        return $this->cache->set($key, $value, $ttl);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete($key)
+    {
+        return $this->cache->delete($key);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear()
+    {
+        return $this->cache->clear();
+    }
+
+    /**
+     * @inheritDoc
+     * @param array|Traversable $keys
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        return $this->cache->getMultiple($keys, $default);
+    }
+
+    /**
+     * @inheritDoc
+     * @param array|Traversable $values
+     * @throws Exception\CacheException
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        return $this->cache->setMultiple($values, $ttl);
+    }
+
+    /**
+     * @inheritDoc
+     * @param array|Traversable $keys
+     */
+    public function deleteMultiple($keys)
+    {
+        return $this->cache->deleteMultiple($keys);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($key)
+    {
+        return $this->cache->has($key);
+    }
+}

--- a/src/TempFileCache.php
+++ b/src/TempFileCache.php
@@ -3,6 +3,7 @@
 
 namespace Vectorface\Cache;
 
+use Exception;
 use Psr\SimpleCache\InvalidArgumentException;
 use Vectorface\Cache\Common\MultipleTrait;
 use Vectorface\Cache\Common\PSR16Util;
@@ -34,7 +35,7 @@ class TempFileCache implements Cache
      *  - Without a directory argument, the system tempdir will be used (e.g. /tmp/TempFileCache/)
      *  - If given a relative path, it will create that directory within the system tempdir.
      *  - If given an absolute path, it will attempt to use that path as-is. Not recommended.
-     * @throws \Exception
+     * @throws Exception
      */
     public function __construct($directory = null, $extension = '.tempcache')
     {
@@ -43,7 +44,7 @@ class TempFileCache implements Cache
 
         $realpath = realpath($this->directory); /* Get rid of extraneous symlinks, ..'s, etc. */
         if (!$realpath) {
-            throw new \Exception("Could not get directory realpath");
+            throw new Exception("Could not get directory realpath");
         }
         $this->directory = $realpath;
 
@@ -54,20 +55,20 @@ class TempFileCache implements Cache
      * Check for a directory's existence and writability, and create otherwise
      *
      * @param string $directory
-     * @throws \Exception
+     * @throws Exception
      */
     private function checkAndCreateDir($directory)
     {
         if (!file_exists($directory)) {
             if (!@mkdir($directory, 0700, true)) {
-                throw new \Exception("Directory does not exist, and could not be created: {$directory}");
+                throw new Exception("Directory does not exist, and could not be created: {$directory}");
             }
         } elseif (is_dir($directory)) {
             if (!is_writable($directory)) {
-                throw new \Exception("Directory is not writable: {$directory}");
+                throw new Exception("Directory is not writable: {$directory}");
             }
         } else {
-            throw new \Exception("Not a directory: {$directory}");
+            throw new Exception("Not a directory: {$directory}");
         }
     }
 

--- a/src/TieredCache.php
+++ b/src/TieredCache.php
@@ -2,6 +2,7 @@
 
 namespace Vectorface\Cache;
 
+use InvalidArgumentException;
 use Vectorface\Cache\Common\PSR16Util;
 
 /**
@@ -52,7 +53,7 @@ class TieredCache implements Cache
         }
         foreach ($caches as $i => $cache) {
             if (!($cache instanceof Cache)) {
-                throw new \InvalidArgumentException("Argument $i is not of class Cache");
+                throw new InvalidArgumentException("Argument $i is not of class Cache");
             }
             $this->caches[] = $cache;
         }


### PR DESCRIPTION
I didn't like the warnings and other goofiness we had to deal with by directly extending the PSR-16 interface.

With this approach, we can directly depend on the `Vectorface\Cache\Cache` interface instead of `Psr\SimpleCache\CacheInterface` and if we ever actually need interop with PSR-16, we can just do `new SimpleCacheAdapter($cache)` to wrap it in something that actually implements `Psr\SimpleCache\CacheInterface` and call it a day.

I'll probably tag a v0.2 version along with the planned increment/decrement additions which will be in a PR to follow. I'll probably not make a separate interface for that seeing as we're moving away from directly extending PSR-16; I can just add it to our existing Cache interface I suppose.