### PR TITLE
Add new AtomicCounter interface, and implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 [![Latest Stable Version](https://poser.pugx.org/vectorface/cache/v/stable.svg)](https://packagist.org/packages/vectorface/cache)
 [![License](https://poser.pugx.org/vectorface/cache/license.svg)](https://packagist.org/packages/vectorface/cache)
 
-This is a simple cache library. It exposes several different caching mechanisms (with different semantics) under a common PSR-16 compatible interface. Nothing fancy.
+This is a simple cache library. It exposes several caching mechanisms (with different semantics), along with support for adapting to a PSR-16 compatible interface, and atomic counters. Nothing fancy.
 
 ## Interface
 
 The cache interface exposes get and set methods, which do exactly what you'd expect from a cache:
 
 ```php
+use Vectorface\Cache\PHPCache;
+
 // PHPCache is a trivial array-backed cache.
-$cache = new \Vectorface\Cache\PHPCache();
+$cache = new PHPCache();
 $cache->get("foo"); // null, because we just created this cache.
 $cache->get("foo", "dflt"); // "dflt"; same as above, but with our own default
 $cache->set("foo", "bar"); // returns true if set. This cache always succeeds.
@@ -23,13 +25,13 @@ The interface supports optional time-to-live (expiry) where supported by the und
 
 ## Available Implementations
 
-* APCCache: APC or APCu.
-* MCCache: Memcache
-* NullCache: A blackhole for your data
-* PHPCache: Stores values in a local variable, for one script execution only.
-* SQLCache: Values stored in an SQL table, accessed via PDO.
-* TempFileCache: Store values in temporary files.
-* TieredCache: Layer any of the above caches on top of each other to form a hybrid cache.
+* `APCCache`: APC or APCu.
+* `MCCache`: Memcache
+* `NullCache`: A blackhole for your data
+* `PHPCache`: Stores values in a local variable, for one script execution only.
+* `SQLCache`: Values stored in an SQL table, accessed via PDO.
+* `TempFileCache`: Store values in temporary files. Does not support atomic counting.
+* `TieredCache`: Layer any of the above caches on top of each other to form a hybrid cache. Does not support atomic counting.
 
 ## Real-World Use
 
@@ -39,14 +41,37 @@ Why would you want to use this? It makes it almost trivial to switch your underl
 use Vectorface\Cache\APCCache;
 use Vectorface\Cache\PHPCache;
 use Vectorface\Cache\TempFileCache;
-// Memcache and SQL-based caches also work, but aren't as good as examples.
 
+// Memcache and SQL-based caches also work, but aren't as good as examples.
 $caches = [new APCCache(), new PHPCache(), new TempFileCache()];
 foreach ($caches as $cache) {
 	// Look ma! Same interface!
 	$cache->set('foo', 'bar');
 	$cache->get('foo');
 }
+```
+
+### Atomic Counters
+
+A common use of caches are to implement atomic counting, i.e. incrementing or decrementing by some amount. Atomicity is important for reliability in distributed environments to avoid race conditions.
+
+Not all cache implementations in this library support atomic counting, because it either isn't possible or doesn't make sense in that context.
+
+```php
+use Vectorface\Cache\APCCache;
+use Vectorface\Cache\AtomicCounter;
+
+$cache = new APCCache();
+assert($cache instanceof AtomicCounter);
+
+// Can increment and decrement by key, defaults to steps of 1
+assert($cache->increment("counter") === 1);
+assert($cache->increment("counter") === 2);
+assert($cache->decrement("counter") === 1);
+
+// Can step by arbitrary amounts
+assert($cache->increment("counter", 5) === 6);
+assert($cache->decrement("counter", 2) === 4);
 ```
 
 ### Tiered Caching
@@ -70,4 +95,18 @@ $cache = new TieredCache([
 $cache->get("foo"); // Tries all caches in sequence until one succeeds. Fails if none succeed.
 $cache->set("foo", "bar"); // Sets a value in all caches.
 $cache->get("foo"); // Tries all caches in sequence. The fastest should succeed and return quickly.
+```
+
+### PSR-16 Support
+
+If you need interoperability with other tooling that support PSR-16 SimpleCache, you may use the `SimpleCacheAdapter` class which can wrap any of the cache implementations in this library.
+
+```php
+use Psr\SimpleCache\CacheInterface;
+use Vectorface\Cache\PHPCache;
+use Vectorface\Cache\SimpleCacheAdapter;
+
+$psr16Cache = new SimpleCacheAdapter(new PHPCache());
+
+assert($psr16Cache instanceof CacheInterface);
 ```

--- a/src/APCCache.php
+++ b/src/APCCache.php
@@ -132,6 +132,22 @@ class APCCache implements Cache
     }
 
     /**
+     * @inheritDoc
+     */
+    public function increment($key, $step = 1)
+    {
+        return $this->call('inc', $this->key($key), $this->step($step));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decrement($key, $step = 1)
+    {
+        return $this->call('dec', $this->key($key), $this->step($step));
+    }
+
+    /**
      * Pass a call through to APC or APCu
      * @param string $call Transformed to a function apc(u)_$call
      * @param mixed ...$args Function arguments

--- a/src/APCCache.php
+++ b/src/APCCache.php
@@ -23,7 +23,7 @@ use Vectorface\Cache\Common\PSR16Util;
 /**
  * Implements the Cache interface on top of APC or APCu.
  */
-class APCCache implements Cache
+class APCCache implements Cache, AtomicCounter
 {
     use PSR16Util;
 

--- a/src/AtomicCounter.php
+++ b/src/AtomicCounter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Vectorface\Cache;
+
+use Vectorface\Cache\Exception\InvalidArgumentException;
+
+/**
+ * Cache: A common interface to caches that support atomic counters
+ */
+interface AtomicCounter
+{
+    /**
+     * Increment the value stored under the given cache key
+     *
+     * @param string $key The unique cache key of the item to increment.
+     * @param int $step Increment the key by this amount, defaults to 1.
+     *
+     * @return int|false The new numeric value, or false on failure.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     *   or if the $step amount is not a legal value.
+     */
+    public function increment($key, $step = 1);
+
+    /**
+     * Decrement the value stored under the given cache key
+     *
+     * @param string $key The unique cache key of the item to decrement.
+     * @param int $step Decrement the key by this amount, defaults to 1.
+     *
+     * @return int|false The new numeric value, or false on failure.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value
+     *   or if the $step amount is not a legal value.
+     */
+    public function decrement($key, $step = 1);
+}

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -134,4 +134,32 @@ interface Cache
      * @return bool True if successful, false otherwise.
      */
     public function flush();
+
+    /**
+     * Increment the value stored under the given cache key
+     *
+     * @param string $key The unique cache key of the item to increment.
+     * @param int $step Increment the key by this amount, defaults to 1.
+     *
+     * @return int|false The new numeric value, or false on failure.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     *   or if the $step amount is not a legal value.
+     */
+    public function increment($key, $step = 1);
+
+    /**
+     * Decrement the value stored under the given cache key
+     *
+     * @param string $key The unique cache key of the item to decrement.
+     * @param int $step Decrement the key by this amount, defaults to 1.
+     *
+     * @return int|false The new numeric value, or false on failure.
+     *
+     * @throws InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value
+     *   or if the $step amount is not a legal value.
+     */
+    public function decrement($key, $step = 1);
 }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -134,32 +134,4 @@ interface Cache
      * @return bool True if successful, false otherwise.
      */
     public function flush();
-
-    /**
-     * Increment the value stored under the given cache key
-     *
-     * @param string $key The unique cache key of the item to increment.
-     * @param int $step Increment the key by this amount, defaults to 1.
-     *
-     * @return int|false The new numeric value, or false on failure.
-     *
-     * @throws InvalidArgumentException
-     *   MUST be thrown if the $key string is not a legal value.
-     *   or if the $step amount is not a legal value.
-     */
-    public function increment($key, $step = 1);
-
-    /**
-     * Decrement the value stored under the given cache key
-     *
-     * @param string $key The unique cache key of the item to decrement.
-     * @param int $step Decrement the key by this amount, defaults to 1.
-     *
-     * @return int|false The new numeric value, or false on failure.
-     *
-     * @throws InvalidArgumentException
-     *   MUST be thrown if the $key string is not a legal value
-     *   or if the $step amount is not a legal value.
-     */
-    public function decrement($key, $step = 1);
 }

--- a/src/CacheHelper.php
+++ b/src/CacheHelper.php
@@ -16,7 +16,7 @@ class CacheHelper
      *     return $giantDataSet;
      * }
      *
-     * One could cache this by adding cache calls to the top/bottom. CacheHelper::fetch can automatate this:
+     * One could cache this by adding cache calls to the top/bottom. CacheHelper::fetch can automate this:
      *
      * function getLargeDataset($arg1, $arg2) {
      *     $key = "SomeClass::LargeDataset($arg1,$arg2)";

--- a/src/Common/PSR16Util.php
+++ b/src/Common/PSR16Util.php
@@ -4,6 +4,7 @@ namespace Vectorface\Cache\Common;
 
 use DateInterval;
 use DateTime;
+use Exception;
 use Traversable;
 use Vectorface\Cache\Exception\CacheException;
 use Vectorface\Cache\Exception\InvalidArgumentException as CacheArgumentException;
@@ -142,7 +143,7 @@ trait PSR16Util
         try {
             $now = new $dateClass();
             $exp = (new $dateClass())->add($interval);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             throw new CacheException("Could not get current DateTime");
         }
 

--- a/src/Common/PSR16Util.php
+++ b/src/Common/PSR16Util.php
@@ -75,6 +75,22 @@ trait PSR16Util
     }
 
     /**
+     * Enforce a valid step value for increment/decrement methods
+     *
+     * @param int $step
+     * @return int
+     * @throws CacheArgumentException Thrown if the step is not a legal value
+     */
+    protected function step($step)
+    {
+        if (!is_integer($step)) {
+            throw new CacheArgumentException("step must be an integer");
+        }
+
+        return $step;
+    }
+
+    /**
      * Add defaults to an array of values from a cache
      *
      * Note: This does NOT check the keys array

--- a/src/LogDecorator.php
+++ b/src/LogDecorator.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
  *   use a different serialization mechanism, so the size should be used to
  *   give an idea of actual cached size rather than an exact value.
  */
-class LogDecorator implements Cache
+class LogDecorator implements Cache, AtomicCounter
 {
     /**
      * The wrapped cache class

--- a/src/LogDecorator.php
+++ b/src/LogDecorator.php
@@ -188,6 +188,38 @@ class LogDecorator implements Cache
     }
 
     /**
+     * @inheritDoc
+     */
+    public function increment($key, $step = 1)
+    {
+        $result = $this->cache->increment($key, $step);
+        $this->log(sprintf(
+            "increment %s by %d %s, value=%d",
+            $key,
+            $step,
+            ($result !== false ? 'SUCCESS' : 'FAILURE'),
+            ($result !== false ? $result : 0)
+        ));
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decrement($key, $step = 1)
+    {
+        $result = $this->cache->decrement($key, $step);
+        $this->log(sprintf(
+            "decrement %s by %d %s, value=%d",
+            $key,
+            $step,
+            ($result !== false ? 'SUCCESS' : 'FAILURE'),
+            ($result !== false ? $result : 0)
+        ));
+        return $result;
+    }
+
+    /**
      * Log a message to the configured logger
      *
      * @param $message

--- a/src/LogDecorator.php
+++ b/src/LogDecorator.php
@@ -4,6 +4,7 @@ namespace Vectorface\Cache;
 
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
+use Vectorface\Cache\Exception\CacheException;
 
 /**
  * Decorates (Wraps) a Cache implementation with logging
@@ -17,7 +18,7 @@ class LogDecorator implements Cache, AtomicCounter
 {
     /**
      * The wrapped cache class
-     * @var Cache
+     * @var Cache|AtomicCounter
      */
     private $cache;
 
@@ -36,7 +37,7 @@ class LogDecorator implements Cache, AtomicCounter
     private $level;
 
     /**
-     * @param Cache $cache
+     * @param Cache|AtomicCounter $cache
      * @param LoggerInterface $log
      * @param string $level
      */
@@ -54,9 +55,12 @@ class LogDecorator implements Cache, AtomicCounter
 
     /**
      * @inheritDoc
+     * @throws CacheException
      */
     public function get($key, $default = null)
     {
+        $this->throwIfNotInstanceof(Cache::class);
+
         $result = $this->cache->get($key);
         if ($result === null) {
             $this->log(sprintf("get %s MISS", $key));
@@ -76,6 +80,8 @@ class LogDecorator implements Cache, AtomicCounter
      */
     public function set($key, $value, $ttl = false)
     {
+        $this->throwIfNotInstanceof(Cache::class);
+
         $result = $this->cache->set($key, $value, $ttl);
         $this->log(sprintf(
             "set %s %s ttl=%s, type=%s, size=%d",
@@ -90,9 +96,12 @@ class LogDecorator implements Cache, AtomicCounter
 
     /**
      * @inheritDoc
+     * @throws CacheException
      */
     public function delete($key)
     {
+        $this->throwIfNotInstanceof(Cache::class);
+
         $result = $this->cache->delete($key);
         $this->log(sprintf(
             "delete %s %s",
@@ -104,9 +113,12 @@ class LogDecorator implements Cache, AtomicCounter
 
     /**
      * @inheritDoc
+     * @throws CacheException
      */
     public function flush()
     {
+        $this->throwIfNotInstanceof(Cache::class);
+
         $result = $this->cache->flush();
         $this->log(sprintf("flush %s", $result ? 'SUCCESS' : 'FAILURE'));
         return $result;
@@ -114,9 +126,12 @@ class LogDecorator implements Cache, AtomicCounter
 
     /**
      * @inheritDoc
+     * @throws CacheException
      */
     public function clean()
     {
+        $this->throwIfNotInstanceof(Cache::class);
+
         $result = $this->cache->clean();
         $this->log(sprintf("clean %s", $result ? 'SUCCESS' : 'FAILURE'));
         return $result;
@@ -124,17 +139,23 @@ class LogDecorator implements Cache, AtomicCounter
 
     /**
      * @inheritDoc
+     * @throws CacheException
      */
     public function clear()
     {
+        $this->throwIfNotInstanceof(Cache::class);
+
         return $this->flush();
     }
 
     /**
      * @inheritDoc
+     * @throws CacheException
      */
     public function getMultiple($keys, $default = null)
     {
+        $this->throwIfNotInstanceof(Cache::class);
+
         $values = $this->cache->getMultiple($keys, $default);
         $this->log(sprintf(
             "getMultiple [%s] count=%s",
@@ -149,6 +170,8 @@ class LogDecorator implements Cache, AtomicCounter
      */
     public function setMultiple($values, $ttl = null)
     {
+        $this->throwIfNotInstanceof(Cache::class);
+
         $result = $this->cache->setMultiple($values, $ttl);
         $this->log(sprintf(
             "setMultiple [%s] %s ttl=%s",
@@ -161,9 +184,12 @@ class LogDecorator implements Cache, AtomicCounter
 
     /**
      * @inheritDoc
+     * @throws CacheException
      */
     public function deleteMultiple($keys)
     {
+        $this->throwIfNotInstanceof(Cache::class);
+
         $result = $this->cache->deleteMultiple($keys);
         $this->log(sprintf(
             "deleteMultiple [%s] %s",
@@ -175,9 +201,12 @@ class LogDecorator implements Cache, AtomicCounter
 
     /**
      * @inheritDoc
+     * @throws CacheException
      */
     public function has($key)
     {
+        $this->throwIfNotInstanceof(Cache::class);
+
         $result = $this->cache->has($key);
         $this->log(sprintf(
             "has %s %s",
@@ -189,9 +218,12 @@ class LogDecorator implements Cache, AtomicCounter
 
     /**
      * @inheritDoc
+     * @throws CacheException
      */
     public function increment($key, $step = 1)
     {
+        $this->throwIfNotInstanceof(AtomicCounter::class);
+
         $result = $this->cache->increment($key, $step);
         $this->log(sprintf(
             "increment %s by %d %s, value=%d",
@@ -205,9 +237,12 @@ class LogDecorator implements Cache, AtomicCounter
 
     /**
      * @inheritDoc
+     * @throws CacheException
      */
     public function decrement($key, $step = 1)
     {
+        $this->throwIfNotInstanceof(AtomicCounter::class);
+
         $result = $this->cache->decrement($key, $step);
         $this->log(sprintf(
             "decrement %s by %d %s, value=%d",
@@ -231,6 +266,19 @@ class LogDecorator implements Cache, AtomicCounter
         }
 
         ([$this->log, $this->level])($message);
+    }
+
+    /**
+     * Guards against calls on a decorated instance that does not support the underlying method
+     *
+     * @param string $class
+     * @throws CacheException
+     */
+    private function throwIfNotInstanceof($class)
+    {
+        if (! $this->cache instanceof $class) {
+            throw new CacheException("This decorated instance does not implement $class");
+        }
     }
 
     /**

--- a/src/MCCache.php
+++ b/src/MCCache.php
@@ -154,7 +154,13 @@ class MCCache implements Cache
      */
     public function increment($key, $step = 1)
     {
-        return $this->mc->increment($this->key($key), $this->step($step));
+        $key = $this->key($key);
+
+        // If the key already exists, this is a no-op, otherwise it ensures the key is created.
+        // See https://www.php.net/manual/en/memcache.increment.php#90864
+        $this->mc->add($key, 0);
+
+        return $this->mc->increment($key, $this->step($step));
     }
 
     /**
@@ -162,6 +168,12 @@ class MCCache implements Cache
      */
     public function decrement($key, $step = 1)
     {
-        return $this->mc->decrement($this->key($key), $this->step($step));
+        $key = $this->key($key);
+
+        // If the key already exists, this is a no-op, otherwise it ensures the key is created.
+        // See https://www.php.net/manual/en/memcache.increment.php#90864
+        $this->mc->add($key, 0);
+
+        return $this->mc->decrement($key, $this->step($step));
     }
 }

--- a/src/MCCache.php
+++ b/src/MCCache.php
@@ -23,7 +23,7 @@ use Vectorface\Cache\Common\PSR16Util;
  * Conclusion:
  *   Capable of approximately 11678 requests/second
  */
-class MCCache implements Cache
+class MCCache implements Cache, AtomicCounter
 {
     use PSR16Util;
 

--- a/src/MCCache.php
+++ b/src/MCCache.php
@@ -148,4 +148,20 @@ class MCCache implements Cache
     {
         return $this->get($this->key($key), null) !== null;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function increment($key, $step = 1)
+    {
+        return $this->mc->increment($this->key($key), $this->step($step));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decrement($key, $step = 1)
+    {
+        return $this->mc->decrement($this->key($key), $this->step($step));
+    }
 }

--- a/src/NullCache.php
+++ b/src/NullCache.php
@@ -5,7 +5,7 @@ namespace Vectorface\Cache;
 /**
  * A cache that caches nothing and always fails.
  */
-class NullCache implements Cache
+class NullCache implements Cache, AtomicCounter
 {
     /**
      * @inheritDoc

--- a/src/NullCache.php
+++ b/src/NullCache.php
@@ -90,4 +90,20 @@ class NullCache implements Cache
     {
         return false;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function increment($key, $step = 1)
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decrement($key, $step = 1)
+    {
+        return false;
+    }
 }

--- a/src/PHPCache.php
+++ b/src/PHPCache.php
@@ -103,4 +103,22 @@ class PHPCache implements Cache
     {
         return $this->get($this->key($key)) !== null;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function increment($key, $step = 1)
+    {
+        $key = $this->key($key);
+        return $this->set($key, $this->get($key, 0) + $this->step($step));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decrement($key, $step = 1)
+    {
+        $key = $this->key($key);
+        return $this->set($key, $this->get($key, 0) - $this->step($step));
+    }
 }

--- a/src/PHPCache.php
+++ b/src/PHPCache.php
@@ -13,7 +13,7 @@ use Vectorface\Cache\Common\MultipleTrait;
  *
  * Capable of a huge number of requests/second
  */
-class PHPCache implements Cache
+class PHPCache implements Cache, AtomicCounter
 {
     use MultipleTrait, PSR16Util;
 

--- a/src/PHPCache.php
+++ b/src/PHPCache.php
@@ -110,7 +110,9 @@ class PHPCache implements Cache, AtomicCounter
     public function increment($key, $step = 1)
     {
         $key = $this->key($key);
-        return $this->set($key, $this->get($key, 0) + $this->step($step));
+        $newValue = $this->get($key, 0) + $this->step($step);
+        $result = $this->set($key, $newValue);
+        return $result !== false ? $newValue : false;
     }
 
     /**
@@ -119,6 +121,8 @@ class PHPCache implements Cache, AtomicCounter
     public function decrement($key, $step = 1)
     {
         $key = $this->key($key);
-        return $this->set($key, $this->get($key, 0) - $this->step($step));
+        $newValue = $this->get($key, 0) - $this->step($step);
+        $result = $this->set($key, $newValue);
+        return $result !== false ? $newValue : false;
     }
 }

--- a/src/SQLCache.php
+++ b/src/SQLCache.php
@@ -38,7 +38,7 @@ use Vectorface\Cache\Common\PSR16Util;
  *     KEY expires (expires)
  * ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
  */
-class SQLCache implements Cache
+class SQLCache implements Cache, AtomicCounter
 {
     use PSR16Util;
 

--- a/src/SQLCache.php
+++ b/src/SQLCache.php
@@ -295,6 +295,78 @@ class SQLCache implements Cache
     }
 
     /**
+     * @inheritDoc
+     * @throws Exception\CacheException
+     */
+    public function increment($key, $step = 1)
+    {
+        $step = $this->step($step);
+
+        try {
+            $result = $this->conn->beginTransaction();
+            if (!$result) {
+                return false;
+            }
+
+            $current = $this->get($key, 0);
+            $next = $current + $step;
+            $result = $this->set($key, $next);
+            if (!$result) {
+                $this->conn->rollBack();
+                return false;
+            }
+
+            $result = $this->conn->commit();
+            if (!$result) {
+                return false;
+            }
+        } catch (PDOException $e) {
+            if ($this->conn->inTransaction()) {
+                $this->conn->rollBack();
+            }
+            return false;
+        }
+
+        return $next;
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exception\CacheException
+     */
+    public function decrement($key, $step = 1)
+    {
+        $step = $this->step($step);
+
+        try {
+            $result = $this->conn->beginTransaction();
+            if (!$result) {
+                return false;
+            }
+
+            $current = $this->get($key, 0);
+            $next = $current - $step;
+            $result = $this->set($key, $next);
+            if (!$result) {
+                $this->conn->rollBack();
+                return false;
+            }
+
+            $result = $this->conn->commit();
+            if (!$result) {
+                return false;
+            }
+        } catch (PDOException $e) {
+            if ($this->conn->inTransaction()) {
+                $this->conn->rollBack();
+            }
+            return false;
+        }
+
+        return $next;
+    }
+
+    /**
      * Get a prepared statement for the given method's SQL.
      *
      * The result is stored internally to limit repeated preparing of SQL.

--- a/src/TempFileCache.php
+++ b/src/TempFileCache.php
@@ -188,22 +188,6 @@ class TempFileCache implements Cache
     }
 
     /**
-     * @inheritDoc
-     */
-    public function increment($key, $step = 1)
-    {
-        return false; // TODO
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function decrement($key, $step = 1)
-    {
-        return false; // TODO
-    }
-
-    /**
      * Creates a file path in the form directory/key.extension
      *
      * @param  string $key the key of the cached element

--- a/src/TempFileCache.php
+++ b/src/TempFileCache.php
@@ -188,10 +188,26 @@ class TempFileCache implements Cache
     }
 
     /**
+     * @inheritDoc
+     */
+    public function increment($key, $step = 1)
+    {
+        return false; // TODO
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decrement($key, $step = 1)
+    {
+        return false; // TODO
+    }
+
+    /**
      * Creates a file path in the form directory/key.extension
      *
-     * @param  String $key the key of the cached element
-     * @return String The file path to the cached element's enclosing file.
+     * @param  string $key the key of the cached element
+     * @return string The file path to the cached element's enclosing file.
      */
     private function makePath($key)
     {

--- a/src/TieredCache.php
+++ b/src/TieredCache.php
@@ -169,6 +169,22 @@ class TieredCache implements Cache
     }
 
     /**
+     * @inheritDoc
+     */
+    public function increment($key, $step = 1)
+    {
+        return false; // TODO: Increment/decrement isn't really compatible with tiered caching, really.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decrement($key, $step = 1)
+    {
+        return false; // TODO: Increment/decrement isn't really compatible with tiered caching, really.
+    }
+
+    /**
      * Run a method on all caches, expect all caches to success for success
      *
      * @param string $call The cache interface method to be called

--- a/src/TieredCache.php
+++ b/src/TieredCache.php
@@ -169,22 +169,6 @@ class TieredCache implements Cache
     }
 
     /**
-     * @inheritDoc
-     */
-    public function increment($key, $step = 1)
-    {
-        return false; // TODO: Increment/decrement isn't really compatible with tiered caching, really.
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function decrement($key, $step = 1)
-    {
-        return false; // TODO: Increment/decrement isn't really compatible with tiered caching, really.
-    }
-
-    /**
      * Run a method on all caches, expect all caches to success for success
      *
      * @param string $call The cache interface method to be called

--- a/tests/APCCacheTest.php
+++ b/tests/APCCacheTest.php
@@ -2,6 +2,9 @@
 
 namespace Vectorface\Tests\Cache;
 
+use Exception;
+use ReflectionClass;
+use ReflectionException;
 use Vectorface\Cache\APCCache;
 
 class APCCacheTest extends GenericCacheTest
@@ -15,11 +18,11 @@ class APCCacheTest extends GenericCacheTest
     }
 
     /**
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testModuleNotAvailable()
     {
-        $cls = new \ReflectionClass('Vectorface\\Cache\\APCCache');
+        $cls = new ReflectionClass(APCCache::class);
         $prop = $cls->getProperty('apcModule');
         $prop->setAccessible(true);
         try {
@@ -27,8 +30,11 @@ class APCCacheTest extends GenericCacheTest
             $orig = $prop->getValue($cache);
             $prop->setValue($cache, 'invalidmodulename');
             $this->fail('The invalidated module name should prevent using this cache.');
-        } catch (\Exception $e) {
-        } // Expected.
+        } catch (Exception $e) {
+            // Expected.
+        }
+
+        /** @noinspection PhpUndefinedVariableInspection */
         $prop->setValue($cache, $orig);
     }
 }

--- a/tests/CacheHelperTest.php
+++ b/tests/CacheHelperTest.php
@@ -2,12 +2,17 @@
 
 namespace Vectorface\Tests\Cache;
 
+use TypeError;
+use Vectorface\Cache\Exception\CacheException;
 use Vectorface\Cache\PHPCache;
 use Vectorface\Cache\CacheHelper;
 use PHPUnit\Framework\TestCase;
 
 class CacheHelperTest extends TestCase
 {
+    /**
+     * @throws CacheException
+     */
     public function testCacheHelper()
     {
         /* A callback that returns "foo" only the first time. */
@@ -34,9 +39,12 @@ class CacheHelperTest extends TestCase
         $this->assertEquals([1], CacheHelper::fetch($cache, 'a3', $callback, [1], 300));
     }
 
+    /**
+     * @throws CacheException
+     */
     public function testBadThings()
     {
-        $this->expectException(\TypeError::class);
+        $this->expectException(TypeError::class);
 
         CacheHelper::fetch(new PHPCache(), $this, function() {
         }, [], 300);

--- a/tests/Common/PSR16UtilTest.php
+++ b/tests/Common/PSR16UtilTest.php
@@ -1,49 +1,53 @@
 <?php
 
-namespace Vectorface\Tests\Cache;
+namespace Vectorface\Tests\Cache\Common;
 
 use DateInterval;
+use ReflectionClass;
+use ReflectionException;
+use stdClass;
+use Vectorface\Cache\Exception\CacheException;
+use Vectorface\Cache\Exception\InvalidArgumentException;
 use Vectorface\Cache\PHPCache;
 use PHPUnit\Framework\TestCase;
 use Vectorface\Tests\Cache\Helpers\BrokenDateTime;
 
 class PSR16UtilTest extends TestCase
 {
-    /**
-     * @expectedException Vectorface\Cache\Exception\InvalidArgumentException
-     */
     public function testEnforcesScalarKey()
     {
-        (new PHPCache)->get(new \stdClass);
+        $this->expectException(InvalidArgumentException::class);
+        (new PHPCache)->get(new stdClass);
     }
 
-    /**
-     * @expectedException Vectorface\Cache\Exception\InvalidArgumentException
-     */
     public function testEnforcesScalarKeys()
     {
-        (new PHPCache)->getMultiple([new \stdClass()]);
+        $this->expectException(InvalidArgumentException::class);
+        (new PHPCache)->getMultiple([new stdClass()]);
     }
 
-    /**
-     * @expectedException Vectorface\Cache\Exception\InvalidArgumentException
-     */
     public function testEnforcesIterableKeys()
     {
+        $this->expectException(InvalidArgumentException::class);
         (new PHPCache)->getMultiple("not array or Traversable");
     }
 
+    /**
+     * @throws CacheException
+     */
     public function testConvertsDateIntervalToTtl()
     {
         $this->assertEquals(86462, PHPCache::ttl(new DateInterval("P0000-00-01T00:01:02")));
     }
 
     /**
-     * @expectedException Vectorface\Cache\Exception\CacheException
+     * @throws CacheException
+     * @throws ReflectionException
      */
     public function testBrokenDateTime()
     {
-        $ref = new \ReflectionClass(\Vectorface\Cache\PHPCache::class);
+        $this->expectException(CacheException::class);
+        $ref = new ReflectionClass(PHPCache::class);
         $prop = $ref->getProperty('dateTimeClass');
         $prop->setAccessible(true);
         $prop->setValue(null, BrokenDateTime::class);

--- a/tests/GenericCacheTest.php
+++ b/tests/GenericCacheTest.php
@@ -194,9 +194,7 @@ abstract class GenericCacheTest extends TestCase
     {
         foreach ($this->getCaches() as $cache) {
             // TODO: Re-enable once support for these is finalized
-            //   Big WTF is that MCCache returns null on decrement for some reason?!?
-            //   MCCache also doesn't create the key with a default of zero like most other caches do.
-            if (in_array(get_class($cache), [MCCache::class, TempFileCache::class])) {
+            if (in_array(get_class($cache), [TempFileCache::class])) {
                 $this->markTestSkipped(get_class($cache) . " does not yet support increment/decrement.");
             }
             $this->assertEquals(1, $cache->increment("counter1", 1), get_class($cache));

--- a/tests/GenericCacheTest.php
+++ b/tests/GenericCacheTest.php
@@ -10,7 +10,10 @@ use stdClass;
 use Vectorface\Cache\Cache;
 use Vectorface\Cache\Exception\CacheException;
 use Vectorface\Cache\Exception\InvalidArgumentException;
+use Vectorface\Cache\MCCache;
 use Vectorface\Cache\SimpleCacheAdapter;
+use Vectorface\Cache\TempFileCache;
+use Vectorface\Cache\TieredCache;
 
 abstract class GenericCacheTest extends TestCase
 {
@@ -181,6 +184,26 @@ abstract class GenericCacheTest extends TestCase
 
             $this->assertNull($cache->get($key));
             $this->assertNull($cache->get($key . ".unrelated"));
+        }
+    }
+
+    /**
+     * @throws IInvalidArgumentException|CacheException
+     */
+    public function testIncrementDecrement()
+    {
+        foreach ($this->getCaches() as $cache) {
+            // TODO: Re-enable once support for these is finalized
+            //   Big WTF is that MCCache returns null on decrement for some reason?!?
+            //   MCCache also doesn't create the key with a default of zero like most other caches do.
+            if (in_array(get_class($cache), [MCCache::class, TempFileCache::class])) {
+                $this->markTestSkipped(get_class($cache) . " does not yet support increment/decrement.");
+            }
+            $this->assertEquals(1, $cache->increment("counter1", 1), get_class($cache));
+            $this->assertEquals(2, $cache->increment("counter1", 1), get_class($cache));
+            $this->assertEquals(7, $cache->increment("counter1", 5), get_class($cache));
+            $this->assertEquals(6, $cache->decrement("counter1", 1), get_class($cache));
+            $this->assertEquals(4, $cache->decrement("counter1", 2), get_class($cache));
         }
     }
 

--- a/tests/Helpers/BrokenDateTime.php
+++ b/tests/Helpers/BrokenDateTime.php
@@ -3,6 +3,7 @@
 namespace Vectorface\Tests\Cache\Helpers;
 
 use DateTime;
+use Exception;
 
 class BrokenDateTime extends DateTime
 {
@@ -10,10 +11,10 @@ class BrokenDateTime extends DateTime
      * @noinspection PhpMissingParentConstructorInspection
      * @noinspection PhpUnusedParameterInspection
      * @param array $args
-     * @throws \Exception
+     * @throws Exception
      */
     public function __construct(...$args)
     {
-        throw new \Exception("I'm broken for tests!");
+        throw new Exception("I'm broken for tests!");
     }
 }

--- a/tests/Helpers/FakeLogger.php
+++ b/tests/Helpers/FakeLogger.php
@@ -3,7 +3,9 @@
 
 namespace Vectorface\Tests\Cache\Helpers;
 
-class FakeLogger implements \Psr\Log\LoggerInterface
+use Psr\Log\LoggerInterface;
+
+class FakeLogger implements LoggerInterface
 {
     private $lastMessage;
 

--- a/tests/Helpers/FakeMemcache.php
+++ b/tests/Helpers/FakeMemcache.php
@@ -136,7 +136,7 @@ class FakeMemcache extends \Memcache
      * @see http://php.net/manual/en/memcache.increment.php
      * @param string $key
      * @param int $value
-     * @return array|bool|mixed
+     * @return int|false
      */
     public function increment($key, $value = 1)
     {
@@ -160,6 +160,7 @@ class FakeMemcache extends \Memcache
      * @see http://php.net/manual/en/memcache.decrement.php
      * @param string $key
      * @param int $value
+     * @return int|false
      */
     public function decrement($key, $value = 1)
     {

--- a/tests/Helpers/FakeMemcache.php
+++ b/tests/Helpers/FakeMemcache.php
@@ -49,6 +49,31 @@ class FakeMemcache extends \Memcache
     }
 
     /**
+     * Mimic Memcache::add
+     *
+     * @see http://php.net/manual/en/memcache.add.php
+     * @param string $key
+     * @param mixed $value
+     * @param int|null $flags
+     * @param int $ttl
+     * @return bool
+     */
+    public function add($key, $value, $flags = null, $ttl = 0)
+    {
+        if ($this->broken) {
+            return false;
+        }
+
+        // Do nothing if the key already exists
+        if (isset(static::$cache[$key])) {
+            return false;
+        }
+
+        static::$cache[$key] = $value;
+        return true;
+    }
+
+    /**
      * Mimic Memcache::set
      *
      * @see http://php.net/manual/en/memcache.set.php
@@ -138,7 +163,7 @@ class FakeMemcache extends \Memcache
      */
     public function decrement($key, $value = 1)
     {
-        $this->increment($key, $value * -1);
+        return $this->increment($key, $value * -1);
     }
 
     /**

--- a/tests/MCCacheTest.php
+++ b/tests/MCCacheTest.php
@@ -2,8 +2,10 @@
 
 namespace Vectorface\Tests\Cache;
 
+use Psr\SimpleCache\InvalidArgumentException;
 use Vectorface\Cache\MCCache;
 use Vectorface\Tests\Cache\Helpers\FakeMemcache;
+use Vectorface\Tests\Cache\Helpers\Memcache;
 
 class MCCacheTest extends GenericCacheTest
 {
@@ -13,14 +15,14 @@ class MCCacheTest extends GenericCacheTest
     {
         if (!class_exists("Memcache", false)) {
             /** @noinspection PhpIgnoredClassAliasDeclaration */
-            class_alias("Vectorface\Tests\Cache\Helpers\Memcache", "Memcache");
+            class_alias(Memcache::class, "Memcache");
         }
         $this->memcache = new FakeMemcache();
         $this->cache = new MCCache($this->memcache);
     }
 
     /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function testGetMultipleWithBrokenCache()
     {

--- a/tests/NullCacheTest.php
+++ b/tests/NullCacheTest.php
@@ -2,13 +2,14 @@
 
 namespace Vectorface\Tests\Cache;
 
+use Vectorface\Cache\Exception\CacheException;
 use Vectorface\Cache\NullCache;
 use PHPUnit\Framework\TestCase;
 
 class NullCacheTest extends TestCase
 {
     /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws CacheException
      */
     public function testNullCache()
     {

--- a/tests/NullCacheTest.php
+++ b/tests/NullCacheTest.php
@@ -24,5 +24,7 @@ class NullCacheTest extends TestCase
         $this->assertFalse($cache->setMultiple(['foo' => 'bar']));
         $this->assertFalse($cache->deleteMultiple(['foo', 'bar']));
         $this->assertFalse($cache->has('foo'));
+        $this->assertFalse($cache->increment('foo'));
+        $this->assertFalse($cache->decrement('foo'));
     }
 }

--- a/tests/PHPCacheTest.php
+++ b/tests/PHPCacheTest.php
@@ -2,6 +2,7 @@
 
 namespace Vectorface\Tests\Cache;
 
+use Vectorface\Cache\Exception\CacheException;
 use Vectorface\Cache\PHPCache;
 
 class PHPCacheTest extends GenericCacheTest
@@ -12,7 +13,7 @@ class PHPCacheTest extends GenericCacheTest
     }
 
     /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws CacheException
      */
     public function testExpired()
     {

--- a/tests/SQLCacheTest.php
+++ b/tests/SQLCacheTest.php
@@ -5,6 +5,9 @@
 
 namespace Vectorface\Tests\Cache;
 
+use PDO;
+use PDOException;
+use Vectorface\Cache\Exception\CacheException;
 use Vectorface\Cache\SQLCache;
 
 class SQLCacheTest extends GenericCacheTest
@@ -17,8 +20,8 @@ class SQLCacheTest extends GenericCacheTest
     protected function setUp()
     {
         try {
-            $this->pdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
-        } catch (\PDOException $e) {
+            $this->pdo = new PDO('sqlite::memory:', null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        } catch (PDOException $e) {
             $this->markTestSkipped("Please ensure that the pdo_sqlite module is installed and configured");
         }
         $this->pdo->sqliteCreateFunction('UNIX_TIMESTAMP', 'time', 0);
@@ -28,7 +31,7 @@ class SQLCacheTest extends GenericCacheTest
     }
 
     /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws CacheException
      * @noinspection DuplicatedCode
      */
     public function testBadThings()
@@ -67,7 +70,7 @@ class SQLCacheTest extends GenericCacheTest
     }
 
     /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws CacheException
      */
     public function testLongKey()
     {
@@ -79,7 +82,7 @@ class SQLCacheTest extends GenericCacheTest
 
         $this->assertEquals(
             serialize($expected),
-            $this->pdo->query("SELECT value FROM cache WHERE entry=\"$hash\"")->fetch(\PDO::FETCH_COLUMN)
+            $this->pdo->query("SELECT value FROM cache WHERE entry=\"$hash\"")->fetch(PDO::FETCH_COLUMN)
         );
 
         $this->assertEquals($expected, $this->cache->get($key));

--- a/tests/TempFileCacheTest.php
+++ b/tests/TempFileCacheTest.php
@@ -2,6 +2,9 @@
 
 namespace Vectorface\Tests\Cache;
 
+use Exception;
+use Psr\SimpleCache\InvalidArgumentException;
+use Vectorface\Cache\Exception\CacheException;
 use Vectorface\Tests\Cache\Helpers\FakeRealpath;
 use Vectorface\Cache\TempFileCache;
 
@@ -21,7 +24,7 @@ class TempFileCacheTest extends GenericCacheTest
     }
 
     /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws CacheException
      * @noinspection PhpUsageOfSilenceOperatorInspection
      */
     public function testBadThings()
@@ -48,14 +51,14 @@ class TempFileCacheTest extends GenericCacheTest
             try {
                 new TempFileCache($dir);
                 $this->fail('TempFileCache should not have been able to initialize');
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
             } // Expected
         }
     }
 
     /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     * @throws \Exception
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function testAlternateDirectory()
     {
@@ -72,7 +75,7 @@ class TempFileCacheTest extends GenericCacheTest
     }
 
     /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws CacheException
      */
     public function testExpiry()
     {
@@ -89,8 +92,8 @@ class TempFileCacheTest extends GenericCacheTest
         try {
             new TempFileCache();
             $this->fail("Expected realpath exception to be thrown");
-        } catch (\Exception $e) {
-            $this->assertTrue($e instanceof \Exception);
+        } catch (Exception $e) {
+            $this->assertTrue($e instanceof Exception);
         }
         FakeRealpath::$broken = false;
     }

--- a/tests/TieredCacheTest.php
+++ b/tests/TieredCacheTest.php
@@ -2,6 +2,8 @@
 
 namespace Vectorface\Tests\Cache;
 
+use InvalidArgumentException;
+use Vectorface\Cache\Exception\CacheException;
 use Vectorface\Cache\NullCache;
 use Vectorface\Cache\PHPCache;
 use Vectorface\Cache\TieredCache;
@@ -10,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 class TieredCacheTest extends TestCase
 {
     /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws CacheException
      */
     public function testTieredCache()
     {
@@ -37,7 +39,7 @@ class TieredCacheTest extends TestCase
 
     public function testBadArg()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         new TieredCache('foo');
     }


### PR DESCRIPTION
Adds `increment` and `decrement` methods and a new AtomicCounter interface.

Implemented support for APCu, SQL, Memcache and PHP caches, plus LogDecorator.

~~Memcache is still WIP because the tests for decrement are failing, returning `null` even though the docs clearly state it should return `false` on failures. Big WTF there.~~ The problem was `FakeMemcache` being incorrectly implemented.

I didn't implement it for TieredCache because it doesn't really make sense I think... how can you have an atomic counter against multiple backends? Unclear to me how that should behave.

Also didn't implement it for TempFileCache either because I didn't feel like trying to deal with file locking right now. We can use `flock()` but if we do that we also need to update the other methods to also use `flock()` to avoid race conditions. Gross.

:thinking: 

Currently targets the `psr-adapter` branch cause I wanted to depend on those changes... will change it to target `master` after that one's merged.