### PR TITLE
Add TTL param for atomic counters

### DIFF
--- a/src/APCCache.php
+++ b/src/APCCache.php
@@ -134,17 +134,17 @@ class APCCache implements Cache, AtomicCounter
     /**
      * @inheritDoc
      */
-    public function increment($key, $step = 1)
+    public function increment($key, $step = 1, $ttl = null)
     {
-        return $this->call('inc', $this->key($key), $this->step($step));
+        return $this->call('inc', $this->key($key), $this->step($step), null, $this->ttl($ttl));
     }
 
     /**
      * @inheritDoc
      */
-    public function decrement($key, $step = 1)
+    public function decrement($key, $step = 1, $ttl = null)
     {
-        return $this->call('dec', $this->key($key), $this->step($step));
+        return $this->call('dec', $this->key($key), $this->step($step), null, $this->ttl($ttl));
     }
 
     /**

--- a/src/AtomicCounter.php
+++ b/src/AtomicCounter.php
@@ -2,6 +2,8 @@
 
 namespace Vectorface\Cache;
 
+use DateInterval;
+use Vectorface\Cache\Exception\CacheException;
 use Vectorface\Cache\Exception\InvalidArgumentException;
 
 /**
@@ -14,26 +16,32 @@ interface AtomicCounter
      *
      * @param string $key The unique cache key of the item to increment.
      * @param int $step Increment the key by this amount, defaults to 1.
+     * @param null|int|DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                   the driver supports TTL then the library may set a default value
+     *                                   for it or let the driver take care of that.
      *
      * @return int|false The new numeric value, or false on failure.
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException|CacheException
      *   MUST be thrown if the $key string is not a legal value.
      *   or if the $step amount is not a legal value.
      */
-    public function increment($key, $step = 1);
+    public function increment($key, $step = 1, $ttl = null);
 
     /**
      * Decrement the value stored under the given cache key
      *
      * @param string $key The unique cache key of the item to decrement.
      * @param int $step Decrement the key by this amount, defaults to 1.
+     * @param null|int|DateInterval $ttl Optional. The TTL value of this item.If no value is sent and
+     *                                   the driver supports TTL then the library may set a default value
+     *                                   for it or let the driver take care of that.
      *
      * @return int|false The new numeric value, or false on failure.
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException|CacheException
      *   MUST be thrown if the $key string is not a legal value
      *   or if the $step amount is not a legal value.
      */
-    public function decrement($key, $step = 1);
+    public function decrement($key, $step = 1, $ttl = null);
 }

--- a/src/LogDecorator.php
+++ b/src/LogDecorator.php
@@ -220,11 +220,11 @@ class LogDecorator implements Cache, AtomicCounter
      * @inheritDoc
      * @throws CacheException
      */
-    public function increment($key, $step = 1)
+    public function increment($key, $step = 1, $ttl = null)
     {
         $this->throwIfNotInstanceof(AtomicCounter::class);
 
-        $result = $this->cache->increment($key, $step);
+        $result = $this->cache->increment($key, $step, $ttl);
         $this->log(sprintf(
             "increment %s by %d %s, value=%d",
             $key,
@@ -239,11 +239,11 @@ class LogDecorator implements Cache, AtomicCounter
      * @inheritDoc
      * @throws CacheException
      */
-    public function decrement($key, $step = 1)
+    public function decrement($key, $step = 1, $ttl = null)
     {
         $this->throwIfNotInstanceof(AtomicCounter::class);
 
-        $result = $this->cache->decrement($key, $step);
+        $result = $this->cache->decrement($key, $step, $ttl);
         $this->log(sprintf(
             "decrement %s by %d %s, value=%d",
             $key,

--- a/src/MCCache.php
+++ b/src/MCCache.php
@@ -152,13 +152,13 @@ class MCCache implements Cache, AtomicCounter
     /**
      * @inheritDoc
      */
-    public function increment($key, $step = 1)
+    public function increment($key, $step = 1, $ttl = null)
     {
         $key = $this->key($key);
 
         // If the key already exists, this is a no-op, otherwise it ensures the key is created.
         // See https://www.php.net/manual/en/memcache.increment.php#90864
-        $this->mc->add($key, 0);
+        $this->mc->add($key, 0, null, $this->ttl($ttl));
 
         return $this->mc->increment($key, $this->step($step));
     }
@@ -166,13 +166,13 @@ class MCCache implements Cache, AtomicCounter
     /**
      * @inheritDoc
      */
-    public function decrement($key, $step = 1)
+    public function decrement($key, $step = 1, $ttl = null)
     {
         $key = $this->key($key);
 
         // If the key already exists, this is a no-op, otherwise it ensures the key is created.
         // See https://www.php.net/manual/en/memcache.increment.php#90864
-        $this->mc->add($key, 0);
+        $this->mc->add($key, 0, null, $this->ttl($ttl));
 
         return $this->mc->decrement($key, $this->step($step));
     }

--- a/src/NullCache.php
+++ b/src/NullCache.php
@@ -94,7 +94,7 @@ class NullCache implements Cache, AtomicCounter
     /**
      * @inheritDoc
      */
-    public function increment($key, $step = 1)
+    public function increment($key, $step = 1, $ttl = null)
     {
         return false;
     }
@@ -102,7 +102,7 @@ class NullCache implements Cache, AtomicCounter
     /**
      * @inheritDoc
      */
-    public function decrement($key, $step = 1)
+    public function decrement($key, $step = 1, $ttl = null)
     {
         return false;
     }

--- a/src/PHPCache.php
+++ b/src/PHPCache.php
@@ -107,22 +107,24 @@ class PHPCache implements Cache, AtomicCounter
     /**
      * @inheritDoc
      */
-    public function increment($key, $step = 1)
+    public function increment($key, $step = 1, $ttl = null)
     {
         $key = $this->key($key);
+        $exists = $this->has($key);
         $newValue = $this->get($key, 0) + $this->step($step);
-        $result = $this->set($key, $newValue);
+        $result = $this->set($key, $newValue, (!$exists ? $ttl : null));
         return $result !== false ? $newValue : false;
     }
 
     /**
      * @inheritDoc
      */
-    public function decrement($key, $step = 1)
+    public function decrement($key, $step = 1, $ttl = null)
     {
         $key = $this->key($key);
+        $exists = $this->has($key);
         $newValue = $this->get($key, 0) - $this->step($step);
-        $result = $this->set($key, $newValue);
+        $result = $this->set($key, $newValue, (!$exists ? $ttl : null));
         return $result !== false ? $newValue : false;
     }
 }

--- a/src/SQLCache.php
+++ b/src/SQLCache.php
@@ -298,7 +298,7 @@ class SQLCache implements Cache, AtomicCounter
      * @inheritDoc
      * @throws Exception\CacheException
      */
-    public function increment($key, $step = 1)
+    public function increment($key, $step = 1, $ttl = null)
     {
         $step = $this->step($step);
 
@@ -308,9 +308,9 @@ class SQLCache implements Cache, AtomicCounter
                 return false;
             }
 
-            $current = $this->get($key, 0);
-            $next = $current + $step;
-            $result = $this->set($key, $next);
+            $current = $this->get($key);
+            $next = ($current ?? 0) + $step;
+            $result = $this->set($key, $next, ($current === null ? $ttl : null));
             if (!$result) {
                 $this->conn->rollBack();
                 return false;
@@ -334,7 +334,7 @@ class SQLCache implements Cache, AtomicCounter
      * @inheritDoc
      * @throws Exception\CacheException
      */
-    public function decrement($key, $step = 1)
+    public function decrement($key, $step = 1, $ttl = null)
     {
         $step = $this->step($step);
 
@@ -344,9 +344,9 @@ class SQLCache implements Cache, AtomicCounter
                 return false;
             }
 
-            $current = $this->get($key, 0);
-            $next = $current - $step;
-            $result = $this->set($key, $next);
+            $current = $this->get($key);
+            $next = ($current ?? 0) - $step;
+            $result = $this->set($key, $next, ($current === null ? $ttl : null));
             if (!$result) {
                 $this->conn->rollBack();
                 return false;


### PR DESCRIPTION
If the counter is newly added, sets the TTL. This is functionality that already existed in APCu and Memcache, and it's hacked in for PHP and SQL but it should work just fine.

Not really possible to test in CI because TTL relies on the clock :hourglass_flowing_sand: 