### PR TITLE
Fix TieredCache `any()` to not short-circuit

### DIFF
--- a/src/TieredCache.php
+++ b/src/TieredCache.php
@@ -179,7 +179,8 @@ class TieredCache implements Cache
     {
         $success = true;
         foreach ($this->caches as $cache) {
-            $success = $success && ([$cache, $call])(...$args);
+            $result = ([$cache, $call])(...$args);
+            $success = $success && $result;
         }
         return $success;
     }
@@ -195,7 +196,8 @@ class TieredCache implements Cache
     {
         $success = false;
         foreach ($this->caches as $cache) {
-            $success = $success || ([$cache, $call])(...$args);
+            $result = ([$cache, $call])(...$args);
+            $success = $success || $result;
         }
         return $success;
     }

--- a/tests/TieredCacheTest.php
+++ b/tests/TieredCacheTest.php
@@ -37,6 +37,29 @@ class TieredCacheTest extends TestCase
         $this->assertFalse($tiered->deleteMultiple(['foo', 'baz'])); // one op failed, so all fail.
     }
 
+    /**
+     * @throws CacheException
+     */
+    public function testTieredSet()
+    {
+        $php1 = new PHPCache();
+        $php2 = new PHPCache();
+        $tiered = new TieredCache($php1, $php2);
+
+        $this->assertNull($tiered->get('foo'));
+        $this->assertTrue($tiered->set('foo', 'bar'));
+        $this->assertEquals('bar', $tiered->get('foo'));
+        $this->assertEquals('bar', $php1->get('foo'));
+        $this->assertEquals('bar', $php2->get('foo'));
+        $this->assertTrue($tiered->flush());
+        $this->assertNull($tiered->get('foo'));
+
+        $this->assertTrue($tiered->setMultiple(['foo' => 'bar', 'baz' => 'quux']));
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'quux'], $tiered->getMultiple(['foo', 'baz']));
+        $this->assertEquals('quux', $php1->get('baz'));
+        $this->assertEquals('bar', $php2->get('foo'));
+    }
+
     public function testBadArg()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
`any()` was buggy because of short circuiting logic preventing it from actually working as described.

The unit tests were incorrect, it wasn't actually testing a properly configured tiered cache, it was testing `NullCache` + `PhpCache`; `NullCache` always returns false so it would not trigger short circuiting to occur, hiding the problem.

The fix is to run the method first, then update `$success` as a separate statement. This ensures it always runs on all caches. Added a test to ensure it works correctly now (fails before the change to `any()`).

Technically I didn't need to change `all()` as well, but did so for symmetry of code.