### PR TITLE
Updates to PSR Simple Cache v2 and v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - develop
   pull_request:
     branches:
       - master
+      - develop
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ on:
 
 jobs:
   test:
-    name: PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
+    name: PHP${{ matrix.php-versions }} | Redis${{ matrix.redis-versions }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
-        redis-versions: ['6.0', '7.x', '8.x']
+        redis-versions: ['6.2', '7.4', '8.0']
 
     steps:
       - name: Checkout
@@ -49,7 +49,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
-        redis-versions: ['6.0']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        redis-versions: ['6.0', '7.x', '8.x']
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=8.0.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "psr/simple-cache": "^1.0",
+        "psr/simple-cache": "^2.0 || ^3.0",
         "cheprasov/php-redis-client": "^1.10"
     },
     "require-dev": {

--- a/src/SimpleCacheAdapter.php
+++ b/src/SimpleCacheAdapter.php
@@ -3,7 +3,6 @@
 namespace Vectorface\Cache;
 
 use Psr\SimpleCache\CacheInterface;
-use Traversable;
 
 /**
  * Adapts a Vectorface cache instance to the PSR SimpleCache interface.
@@ -12,8 +11,6 @@ class SimpleCacheAdapter implements CacheInterface
 {
     /**
      * Create an adapter over a Vectorface cache instance to the SimpleCache interface.
-     *
-     * @param Cache $cache
      */
     public function __construct(
         protected Cache $cache,
@@ -22,7 +19,7 @@ class SimpleCacheAdapter implements CacheInterface
     /**
      * @inheritDoc
      */
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         return $this->cache->get($key, $default);
     }
@@ -31,7 +28,7 @@ class SimpleCacheAdapter implements CacheInterface
      * @inheritDoc
      * @throws Exception\CacheException
      */
-    public function set($key, $value, $ttl = null) : bool
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
     {
         return $this->cache->set($key, $value, $ttl);
     }
@@ -39,7 +36,7 @@ class SimpleCacheAdapter implements CacheInterface
     /**
      * @inheritDoc
      */
-    public function delete($key) : bool
+    public function delete(string $key): bool
     {
         return $this->cache->delete($key);
     }
@@ -54,28 +51,25 @@ class SimpleCacheAdapter implements CacheInterface
 
     /**
      * @inheritDoc
-     * @param array|Traversable $keys
      */
-    public function getMultiple($keys, $default = null) : iterable
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         return $this->cache->getMultiple($keys, $default);
     }
 
     /**
      * @inheritDoc
-     * @param array|Traversable $values
      * @throws Exception\CacheException
      */
-    public function setMultiple($values, $ttl = null) : bool
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
     {
         return $this->cache->setMultiple($values, $ttl);
     }
 
     /**
      * @inheritDoc
-     * @param array|Traversable $keys
      */
-    public function deleteMultiple($keys) : bool
+    public function deleteMultiple(iterable $keys): bool
     {
         return $this->cache->deleteMultiple($keys);
     }
@@ -83,7 +77,7 @@ class SimpleCacheAdapter implements CacheInterface
     /**
      * @inheritDoc
      */
-    public function has($key) : bool
+    public function has(string $key): bool
     {
         return $this->cache->has($key);
     }


### PR DESCRIPTION
Updates the package to be compatible with PSR Simple Cache versions 2 and 3.

- Updates the `psr/simple-cache` dependency in `composer.json` to allow versions ^2.0 || ^3.0.
- Modifies the `SimpleCacheAdapter` to align with changes in PSR-16. This primarily involves type hinting and return type declarations for better compatibility and code clarity.